### PR TITLE
Add qwen38-vision download target for the Qwen3.8 vision encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ the [client setup guide](docs/CLIENTS.md).
 
 [Models and vision](docs/MODELS.md) lists the supported downloads and memory
 requirements. DeepSeek Vision Experimental uses a different checkpoint from
-Flash 0731; GLM 5.3 Flash adds vision to the same text model.
+Flash 0731; GLM 5.3 Flash and Qwen3.8 Flash Next add vision to the same text
+model through a separate encoder.
 
 With the matching encoder passed as `--vision FILE`, use `/read image.png`
 in the CLI or `view_image` in the native agent.
@@ -167,7 +168,10 @@ Qwen3.8 uses one combined main/MTP GGUF plus a required external PLE sidecar:
 ```
 
 The download updates `ds4flash.gguf` to the combined model. Omit `--mtp` for
-ordinary decode with the same files. See [Qwen setup](docs/QWEN38_FLASH_NEXT.md)
+ordinary decode with the same files. Vision uses a separate encoder;
+`./download_model.sh qwen38-vision` downloads it, and you pass it as
+`--vision gguf/mmproj-Qwen3.8-Flash-Next-Q8_0.gguf`. See
+[Qwen setup](docs/QWEN38_FLASH_NEXT.md)
 for details; if using `DS4_GGUF_DIR`, adjust the PLE path accordingly.
 
 Speculative decoding is opt-in. GLM and Qwen use `--mtp`; Flash DSpark needs a matching

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -59,6 +59,11 @@ Omit `--mtp` for ordinary decode; both modes use the same model and sidecar.
 Adjust the PLE path if you set `DS4_GGUF_DIR`. See [Qwen setup](QWEN38_FLASH_NEXT.md)
 for memory, conversion, vision, and sampling details.
 
+Vision uses a separate encoder. `./download_model.sh qwen38-vision` downloads
+llama.cpp's Q8_0 mmproj from
+[ggml-org/Qwen3.8-Flash-Next-GGUF](https://huggingface.co/ggml-org/Qwen3.8-Flash-Next-GGUF);
+pass it at runtime with `--vision`.
+
 ## GLM 5.3 Flash
 
 | Target | Approximate file size | Use |
@@ -148,3 +153,17 @@ be saved with `/save`.
 For two-Mac TP, pass the same encoder on both ranks. The coordinator encodes
 the image and sends the projected visual tokens to the worker.
 For HTTP image formats and limits, see [serving](SERVER.md#images).
+
+### Qwen3.8 Flash Next
+
+The text GGUF stays the same. Download and add the encoder explicitly:
+
+```sh
+./download_model.sh qwen38-vision
+./ds4 --ple gguf/Qwen3.8-Flash-Next-PLE-Q4_1.gguf --mtp \
+  --vision gguf/mmproj-Qwen3.8-Flash-Next-Q8_0.gguf
+```
+
+The encoder is llama.cpp's Q8_0 mmproj conversion of the model's Qwen3-VL
+tower. Use `/read image.png` in `ds4` or `image_url` parts over HTTP; see
+[Qwen setup](QWEN38_FLASH_NEXT.md) for image limits and resize behavior.

--- a/docs/QWEN38_FLASH_NEXT.md
+++ b/docs/QWEN38_FLASH_NEXT.md
@@ -25,6 +25,12 @@ Adjust the PLE path if you set `DS4_GGUF_DIR`. The external PLE table is mapped
 separately, allowing this release to run on 128 GB Macs; context size and other
 workloads still affect memory use.
 
+Vision needs llama.cpp's mmproj encoder, which is a separate download:
+
+```sh
+./download_model.sh qwen38-vision
+```
+
 ## Build your own GGUF
 
 Build the
@@ -141,8 +147,9 @@ applies the static YaRN scaling from the model card, up to about 1M tokens;
 use a factor of 2 for 512k. Static YaRN costs a little accuracy on short
 prompts, so leave it off otherwise.
 
-Images go through the model's Qwen3-VL vision tower. Pass llama.cpp's mmproj
-file (`ggml-org/Qwen3.8-Flash-Next-GGUF` ships a Q8_0 one, or run
+Images go through the model's Qwen3-VL vision tower. Download llama.cpp's
+mmproj file with `./download_model.sh qwen38-vision` (it comes from
+`ggml-org/Qwen3.8-Flash-Next-GGUF`; alternatively run
 `convert_hf_to_gguf.py --mmproj --outtype f16` on the checkpoint) with
 `--vision` and send `image_url` parts as usual. Each image is resized to
 multiples of 32 pixels within 64 to 1024 tokens (`DS4_QWEN4_IMAGE_MAX_TOKENS`

--- a/download_model.sh
+++ b/download_model.sh
@@ -7,6 +7,7 @@ GLM53_REPO="antirez/glm-5.3-flash-gguf"
 GLM53_FULL_REPO="antirez/glm-5.3-gguf"
 # Qwen3.8 DS4 release; will move to the antirez org — flip this one line then.
 QWEN38_REPO="ivanfioravanti/Qwen3.8-Flash-Next-DS4-Q4"
+QWEN38_MMPROJ_REPO="ggml-org/Qwen3.8-Flash-Next-GGUF"
 REPO="antirez/deepseek-v4-gguf"
 DS4F_Q2_FILE="DeepSeek-V4-Flash-IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8-chat-v2-imatrix-0731.gguf"
 DS4F_Q4_FILE="DeepSeek-V4-Flash-Q4KExperts-F16HC-F16Compressor-F16Indexer-Q8Attn-Q8Shared-Q8Out-chat-v2-imatrix-0731.gguf"
@@ -34,6 +35,7 @@ GLM53_FP8_FILE="GLM-5.3-Flash-FP8.gguf"
 GLM53_VISION_FILE="GLM-5.3-Flash-Vision-Encoder.gguf"
 QWEN38_Q4K_MTP_FILE="Qwen3.8-Flash-Next-Q4KImatrixExperts-MXFP4Down-BF16Emb-BF16Control-Q8GDN-Q8QSA-Q8Shared-Q8Out-MTP.gguf"
 QWEN38_PLE_FILE="Qwen3.8-Flash-Next-PLE-Q4_1.gguf"
+QWEN38_VISION_FILE="mmproj-Qwen3.8-Flash-Next-Q8_0.gguf"
 
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 OUT_DIR=${DS4_GGUF_DIR:-"$ROOT/gguf"}
@@ -72,6 +74,7 @@ Usage:
   ./download_model.sh glm53-fp8 [--token TOKEN]
   ./download_model.sh glm53-vision [--token TOKEN]
   ./download_model.sh qwen38-q4k [--token TOKEN]
+  ./download_model.sh qwen38-vision [--token TOKEN]
 
 Targets:
 
@@ -180,6 +183,10 @@ Targets:
        GGUF supports ordinary decode or optional speculation with --mtp
        (--mtp-exact-sampling for exact sampling under speculation).
        Fits 128 GB Macs (~68 GiB resident).
+
+  qwen38-vision
+       Qwen3.8-Flash-Next vision encoder, about 0.6 GB on disk. Load it
+       with --vision; this target does not update ./ds4flash.gguf.
 
 Options:
   --token TOKEN  Hugging Face token. Otherwise HF_TOKEN or the local HF token
@@ -315,6 +322,12 @@ case "$MODEL" in
         MODEL_FILE=$QWEN38_Q4K_MTP_FILE
         MODEL_FILES="$MODEL_FILE $QWEN38_PLE_FILE"
         FORCE_HF_DOWNLOAD=1
+        ;;
+    qwen38-vision)
+        REPO=$QWEN38_MMPROJ_REPO
+        MODEL_FILE=$QWEN38_VISION_FILE
+        FORCE_HF_DOWNLOAD=1
+        LINK_MODEL=0
         ;;
     -h|--help|help)
         usage
@@ -507,4 +520,10 @@ echo "Done."
 if [ "$MODEL" = qwen38-q4k ]; then
     echo "Run with the required PLE sidecar (omit --mtp for ordinary decode):"
     printf '  ./ds4 --ple "%s/%s" --mtp\n' "$OUT_DIR" "$QWEN38_PLE_FILE"
+fi
+if [ "$MODEL" = qwen38-vision ]; then
+    echo
+    echo "Qwen3.8 vision encoder downloaded. Pass it with --vision, for example:"
+    printf '  ./ds4 --ple "%s/%s" --mtp --vision "%s/%s"\n' \
+        "$OUT_DIR" "$QWEN38_PLE_FILE" "$OUT_DIR" "$QWEN38_VISION_FILE"
 fi


### PR DESCRIPTION
## Summary

Qwen3.8-Flash-Next vision is fully implemented in this fork (the Qwen3-VL tower in `ds4.c`, `metal/qwen4_vision.metal`, `make test-qwen4-vision`), but `download_model.sh` never fetched the encoder, so `--vision` could not be used out of the box: users got the model running and then hit a missing `mmproj` file.

This PR follows the same process used for DeepSeek V4 Flash Vision and GLM 5.3 Flash: a standalone encoder download target that leaves `ds4flash.gguf` untouched, plus documentation updates.

## Changes

**`download_model.sh`**
- New `qwen38-vision` target, mirroring `glm53-vision`: downloads llama.cpp's Q8_0 mmproj (`mmproj-Qwen3.8-Flash-Next-Q8_0.gguf`, about 0.6 GB) from [ggml-org/Qwen3.8-Flash-Next-GGUF](https://huggingface.co/ggml-org/Qwen3.8-Flash-Next-GGUF) (`QWEN38_MMPROJ_REPO`), with `LINK_MODEL=0`
- Usage/help text: new target line and description
- On completion, prints the exact run command, e.g.:
  ```
  ./ds4 --ple <OUT_DIR>/Qwen3.8-Flash-Next-PLE-Q4_1.gguf --mtp --vision <OUT_DIR>/mmproj-Qwen3.8-Flash-Next-Q8_0.gguf
  ```

**Docs** (consistent with how DeepSeek/GLM vision is documented)
- `README.md`: the "Models, images, and speculation" section now states that GLM 5.3 Flash *and* Qwen3.8 Flash Next add vision via a separate encoder, and the Qwen quickstart mentions `qwen38-vision` + `--vision`
- `docs/MODELS.md`: Qwen section gains the encoder download note; new "### Qwen3.8 Flash Next" subsection under Vision, parallel to the GLM one
- `docs/QWEN38_FLASH_NEXT.md`: "Download and run" includes `./download_model.sh qwen38-vision`; the vision paragraph points to it as the download path for the mmproj

## Testing

- `sh -n download_model.sh` passes
- `./download_model.sh --help` renders the new target description correctly
- `./download_model.sh qwen38-vision` verified end-to-end on a machine with the encoder already present: it short-circuits with `Already downloaded` and prints the correct `--vision` run command
- Vision verified working at runtime with `--vision gguf/mmproj-Qwen3.8-Flash-Next-Q8_0.gguf` (`/read image.png` in the CLI encodes and answers correctly)

## Notes

- The mmproj lives in a separate repo from the DS4 Q4 release (same situation as the GLM encoder living in `antirez/glm-5.3-flash-gguf`); if the mmproj is later mirrored into the DS4 release repo, only `QWEN38_MMPROJ_REPO` needs to change.
- The target uses the same Hugging Face CLI path as `glm53-vision` (`FORCE_HF_DOWNLOAD=1`); the script already prints install instructions when the CLI is missing.