### PR TITLE
Qwen3.8-Flash-Next: bit-exact M5 Max prefill/decode optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,14 @@ speed-bench/metal_prefill_variant_bench: speed-bench/metal_prefill_variant_bench
 
 metal-prefill-variant-bench: speed-bench/metal_prefill_variant_bench
 
+speed-bench/qwen38_decode_variant_bench.o: speed-bench/qwen38_decode_variant_bench.c ds4.h
+	$(CC) $(CFLAGS) -I. -c -o $@ $<
+
+speed-bench/qwen38_decode_variant_bench: speed-bench/qwen38_decode_variant_bench.o $(CORE_OBJS)
+	$(CC) $(CFLAGS) -o $@ $^ $(METAL_LDLIBS)
+
+qwen38-decode-variant-bench: speed-bench/qwen38_decode_variant_bench
+
 tests/test_mxfp4_metal.o: tests/test_mxfp4_metal.c ds4_gpu.h
 	$(CC) $(CFLAGS) -I. -c -o $@ $<
 
@@ -860,6 +868,6 @@ clean:
 	rm -f tests/test_ssd_cache
 	rm -f tests/test_session_state tests/test_session_state_gpu tests/test_tp_commands
 	rm -f tests/test_metal_tp_spec
-	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official gguf-tools/quality-testing/score_official.o speed-bench/metal_decode_schedule_bench speed-bench/metal_prefill_variant_bench speed-bench/*.o tests/test_q4k_dot tests/test_mxfp4_dot tests/test_mxfp4_metal tests/test_mxfp4_rocm tests/test_mxfp4_cuda tests/test_metal_session_batch tests/test_metal_moe_prefill tests/test_qwen4_moe_mm_specialize tests/test_qwen4_conv_parallel tests/test_q8_prefill_variants tests/test_metal_dense_mpp tests/test_glm53_kda tests/test_glm53_kda_rocm tests/test_glm53_vision_engine tests/test_glm53_vision_prompt tests/test_deepseek4_vision_image tests/test_prompt_prefix tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/*.o *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o
+	rm -f ds4 ds4-server ds4-bench ds4-eval ds4-agent ds4_cpu ds4_native ds4_server_test ds4_test ds4_agent_test gguf-tools/quality-testing/score_official gguf-tools/quality-testing/score_official.o speed-bench/metal_decode_schedule_bench speed-bench/metal_prefill_variant_bench speed-bench/qwen38_decode_variant_bench speed-bench/*.o tests/test_q4k_dot tests/test_mxfp4_dot tests/test_mxfp4_metal tests/test_mxfp4_rocm tests/test_mxfp4_cuda tests/test_metal_session_batch tests/test_metal_moe_prefill tests/test_qwen4_moe_mm_specialize tests/test_qwen4_conv_parallel tests/test_q8_prefill_variants tests/test_metal_dense_mpp tests/test_glm53_kda tests/test_glm53_kda_rocm tests/test_glm53_vision_engine tests/test_glm53_vision_prompt tests/test_deepseek4_vision_image tests/test_prompt_prefix tests/test_gpu_xdev tests/test_gpu_model_cache tests/test_gpu_lookup_cache_strict tests/test_engine_mgpu_refusal tests/test_engine_mgpu_runtime tests/test_engine_correctness tests/test_sampling tests/test_cuda_session_batch tests/test_cuda_mixed_batch tests/*.o *.o tests/cuda_long_context_smoke tests/cuda_long_context_smoke.o
 	rm -f tests/test_qwen4_kernels tests/test_qwen4_vision
 	rm -f $(QWEN4_HOST_TEST) $(QWEN4_SPEC_TEST)

--- a/docs/QWEN38_FLASH_NEXT.md
+++ b/docs/QWEN38_FLASH_NEXT.md
@@ -102,6 +102,18 @@ stay off on M5, where they measured slower. See
 [the M5 Max round-one report](../speed-bench/qwen38-m5-round1.md) for the
 single-engine A/B measurements, exact-logit checks and the sweep through 128K.
 
+The second M5 round adds, still bit-exact: narrow single-token F16/F32
+matvecs (hyper-connection low-rank down, router) launched one row per SIMD
+group (`DS4_METAL_PLAIN_MV_NR0`), 1024-thread GDN front threadgroups
+(`DS4_QWEN4_GDN_FRONT_THREADS`), expert-major prefill tile order
+(`DS4_QWEN4_MOE_MM_ORDER`), a decode indexer scorer with staged queries and
+vector key loads, a one-thread-per-dim split-attention merge and an exact
+tile-max prefiltered top-k for long contexts (`DS4_QWEN4_IDX_SCORE_VEC`,
+`DS4_QWEN4_ATTN_MERGE_WIDE`, `DS4_QWEN4_IDX_PREFILTER`), and, on every
+device, an MTP rejection rollback that swaps the live and snapshot state
+buffers instead of copying them (`DS4_QWEN4_MTP_SWAP_RESTORE=0` restores the
+copy). See [the round-two report](../speed-bench/qwen38-m5-round2.md).
+
 The older recipes below keep PLE inside the main GGUF, so their file sizes
 are not directly comparable with the external-PLE builds.
 

--- a/docs/QWEN38_FLASH_NEXT.md
+++ b/docs/QWEN38_FLASH_NEXT.md
@@ -92,6 +92,16 @@ MTP sessions retain the separate operations, as do other devices by default. See
 [ordinary-decode fusion measurements](../speed-bench/qwen38-q2-decode-fusions.md)
 for the measured gain, exact-logit checks, and rejected experiments.
 
+On Apple M5, routed-expert prefill GEMMs specialize the bound quantization
+by default, single-token Q4_K gate/up decode uses one row per SIMD group with
+four groups per threadgroup, and MXFP4 routed-down decode rows specialize the
+quantization with sixteen SIMD groups per threadgroup. The same overrides
+apply (`DS4_QWEN4_MOE_MM_SPECIALIZE`, `DS4_QWEN4_Q4K_MID_NR`/`_NSG`,
+`DS4_QWEN4_MOE_MV_SPECIALIZE`/`_NSG`); the M3 Ultra ordinary-decode fusions
+stay off on M5, where they measured slower. See
+[the M5 Max round-one report](../speed-bench/qwen38-m5-round1.md) for the
+single-engine A/B measurements, exact-logit checks and the sweep through 128K.
+
 The older recipes below keep PLE inside the main GGUF, so their file sizes
 are not directly comparable with the external-PLE builds.
 

--- a/ds4.c
+++ b/ds4.c
@@ -55645,6 +55645,35 @@ static bool qwen4_graph_state_copy(ds4_qwen4_gpu_graph *g, bool save) {
     return ok;
 }
 
+/* A rejected draft returns to the state the verify snapshotted after row 0,
+ * and that snapshot is a complete copy: swap the live and snapshot buffers
+ * instead of copying 36 layers of recurrent state back through the GPU.
+ * The stale buffers become the next snapshot targets, which every snapshot
+ * kernel overwrites in full, so the snapshot is marked invalid until then.
+ * DS4_QWEN4_MTP_SWAP_RESTORE=0 keeps the copying restore for comparisons. */
+static bool qwen4_graph_state_swap(ds4_qwen4_gpu_graph *g) {
+    if (!g->snap_ple_hist) return false;
+    const char *env = getenv("DS4_QWEN4_MTP_SWAP_RESTORE");
+    if (env && env[0] && strcmp(env, "0") == 0) return qwen4_graph_state_copy(g, false);
+    for (uint32_t il = 0; il < DS4_N_LAYER; il++) {
+        if (!g->snap_lin_state[il]) continue;
+        ds4_gpu_tensor *t = g->layer_lin_state[il];
+        g->layer_lin_state[il] = g->snap_lin_state[il];
+        g->snap_lin_state[il] = t;
+        t = g->layer_lin_hist[il];
+        g->layer_lin_hist[il] = g->snap_lin_hist[il];
+        g->snap_lin_hist[il] = t;
+    }
+    ds4_gpu_tensor *t = g->ple_hist;
+    g->ple_hist = g->snap_ple_hist;
+    g->snap_ple_hist = t;
+    memcpy(g->ple_prev, g->snap_ple_prev, sizeof(g->ple_prev));
+    g->pos = g->snap_pos;
+    g->mrope_delta = g->snap_mrope_delta;
+    g->snap_valid = false;
+    return true;
+}
+
 /* One or two causal predictor steps at idx, using consecutive rows of the
  * trunk's pre-mixer streams and the embeddings of their following tokens.
  * The nextn layer runs on its own residual; want_logits returns the last
@@ -69974,7 +70003,7 @@ static int ds4_session_qwen4_spec_cycle(ds4_session *s, int first_token, float t
         accepted[1] = d;
         return 2;
     }
-    if (!g->snap_valid || !qwen4_graph_state_copy(g, false)) {
+    if (!g->snap_valid || !qwen4_graph_state_swap(g)) {
         if (errlen) snprintf(err, errlen, "Qwen3.8 mtp: rejection restore failed");
         s->checkpoint_valid = false;
         return -1;

--- a/ds4.c
+++ b/ds4.c
@@ -54838,7 +54838,7 @@ typedef struct {
     ds4_gpu_tensor *ple_emb, *ple_key, *ple_val, *ple_gated, *ple_normed, *ple_hist;
     int ple_prev[DS4_MAX_PLE_NGRAM];
     ds4_gpu_tensor *qg, *kp, *vp, *iq, *ik, *q, *gate, *iqn, *attn_o;
-    ds4_gpu_tensor *score, *sel_blocks, *sel_tokens, *n_sel, *attn_part;
+    ds4_gpu_tensor *score, *tile_max, *sel_blocks, *sel_tokens, *n_sel, *attn_part;
     ds4_gpu_tensor *router, *selected, *weights, *mid, *part, *sh_gate_logit;
     ds4_gpu_tensor *moe_lists, *moe_counts, *sh_gate, *sh_up, *sh_mid, *sh_out, *hc_u, *hc_lo_act;
     ds4_gpu_tensor *logits;
@@ -54977,7 +54977,7 @@ static void qwen4_graph_free(ds4_qwen4_gpu_graph *g) {
         &g->R, &g->xn, &g->lo, &g->inj, &g->mixed, &g->blk, &g->qkv, &g->z, &g->ga, &g->gb, &g->lin_o,
         &g->ple_emb, &g->ple_key, &g->ple_val, &g->ple_gated, &g->ple_normed, &g->ple_hist,
         &g->qg, &g->kp, &g->vp, &g->iq, &g->ik, &g->q, &g->gate, &g->iqn, &g->attn_o,
-        &g->score, &g->sel_blocks, &g->sel_tokens, &g->n_sel, &g->attn_part,
+        &g->score, &g->tile_max, &g->sel_blocks, &g->sel_tokens, &g->n_sel, &g->attn_part,
         &g->router, &g->selected, &g->weights, &g->mid, &g->part, &g->sh_gate_logit, &g->logits,
         &g->moe_lists, &g->moe_counts, &g->sh_gate, &g->sh_up, &g->sh_mid, &g->sh_out, &g->hc_u, &g->hc_lo_act,
         &g->inj_alt, &g->mtp_e, &g->mtp_cat, &g->mtp_proj, &g->mtp_R, &g->mtp_argmax, &g->mtp_argmax_tmp, &g->snap_ple_hist, &g->pos3,
@@ -55063,6 +55063,7 @@ static bool qwen4_graph_alloc(ds4_qwen4_gpu_graph *g, const ds4_weights *w, uint
     QWEN4_ALLOC(iqn, T * iq_dim);
     QWEN4_ALLOC(attn_o, T * q_dim);
     QWEN4_ALLOC(score, T * g->n_block_cap);
+    QWEN4_ALLOC(tile_max, T * (g->n_block_cap / 8u + 1u));
     QWEN4_ALLOC(sel_blocks, T * g->k_blocks);
     QWEN4_ALLOC(sel_tokens, T * g->sel_stride);
     QWEN4_ALLOC(n_sel, T);
@@ -55180,12 +55181,12 @@ static bool qwen4_graph_fused(uint32_t T) {
 }
 
 /* top-k blocks per query: radix select (DS4_QWEN4_NO_IDX_SELECT=1 restores the argsort path) */
-static int qwen4_idx_select(ds4_gpu_tensor *sel, const ds4_gpu_tensor *score, uint32_t n_blocks,
-                            uint32_t n_tokens, uint32_t top_k) {
+static int qwen4_idx_select(ds4_gpu_tensor *sel, const ds4_gpu_tensor *score, const ds4_gpu_tensor *tile_max,
+                            uint32_t n_blocks, uint32_t n_tokens, uint32_t top_k) {
     static int no_select = -1;
     if (no_select < 0) no_select = getenv("DS4_QWEN4_NO_IDX_SELECT") != NULL;
     return no_select ? ds4_gpu_indexer_topk_tensor(sel, score, n_blocks, n_tokens, top_k)
-                     : ds4_gpu_qwen4_idx_select_tensor(sel, score, n_blocks, n_tokens, top_k);
+                     : ds4_gpu_qwen4_idx_select_tensor(sel, score, tile_max, n_blocks, n_tokens, top_k);
 }
 
 /* grouped norm -> low-rank gate -> mixed; inject may be NULL (final mixer) */
@@ -55318,9 +55319,11 @@ static bool qwen4_graph_attention(ds4_qwen4_gpu_graph *g, const ds4_model *m, co
                 (uint64_t)n_dense * DS4_N_INDEXER_HEAD * DS4_N_INDEXER_HEAD_DIM * sizeof(float),
                 (uint64_t)n_sparse * DS4_N_INDEXER_HEAD * DS4_N_INDEXER_HEAD_DIM * sizeof(float));
         bool ok = q && gate && o && iqn &&
-            ds4_gpu_qwen4_idx_score_tensor(g->score, iqn, g->layer_block_key[il], n_sparse, n_blocks_after,
+            ds4_gpu_qwen4_idx_score_tensor(g->score, n_sparse <= 2u ? g->tile_max : NULL, iqn,
+                                           g->layer_block_key[il], n_sparse, n_blocks_after,
                                            DS4_N_INDEXER_HEAD, DS4_N_INDEXER_HEAD_DIM, sp0, ratio) &&
-            qwen4_idx_select(g->sel_blocks, g->score, n_blocks_after, n_sparse, g->k_blocks) &&
+            qwen4_idx_select(g->sel_blocks, g->score, n_sparse <= 2u ? g->tile_max : NULL,
+                             n_blocks_after, n_sparse, g->k_blocks) &&
             ds4_gpu_qwen4_idx_expand_tensor(g->sel_tokens, g->n_sel, g->sel_blocks, n_sparse, g->k_blocks, ratio,
                                             sp0, g->sel_stride) &&
             ds4_gpu_qwen4_attn_decode_tensor(o, q, gate, g->layer_k_cache[il], g->layer_v_cache[il],

--- a/ds4_gpu.h
+++ b/ds4_gpu.h
@@ -3401,11 +3401,12 @@ int ds4_gpu_qwen4_idx_block_key_tensor(
         uint32_t block0, uint32_t n_blocks, uint32_t ratio, uint32_t idx_dim, uint32_t n_rot,
         float rope_base, float eps);
 int ds4_gpu_qwen4_idx_score_tensor(
-        ds4_gpu_tensor *score, const ds4_gpu_tensor *iq, const ds4_gpu_tensor *block_key,
+        ds4_gpu_tensor *score, ds4_gpu_tensor *tile_max, const ds4_gpu_tensor *iq, const ds4_gpu_tensor *block_key,
         uint32_t n_tokens, uint32_t n_blocks, uint32_t n_idx_head, uint32_t idx_dim,
         uint32_t pos0, uint32_t ratio);
 int ds4_gpu_qwen4_idx_select_tensor(
-        ds4_gpu_tensor *sel, const ds4_gpu_tensor *score, uint32_t n_blocks, uint32_t n_tokens, uint32_t top_k);
+        ds4_gpu_tensor *sel, const ds4_gpu_tensor *score, const ds4_gpu_tensor *tile_max,
+        uint32_t n_blocks, uint32_t n_tokens, uint32_t top_k);
 int ds4_gpu_qwen4_idx_expand_tensor(
         ds4_gpu_tensor *sel_tokens, ds4_gpu_tensor *n_sel, const ds4_gpu_tensor *sel_blocks,
         uint32_t n_tokens, uint32_t n_sel_blocks, uint32_t ratio, uint32_t pos0, uint32_t sel_stride);

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -47879,10 +47879,12 @@ int ds4_gpu_qwen4_gdn_scan_tensor(
          * preserves the recurrent arithmetic. M3 Ultra prefers eight groups
          * for verification and four at the measured large-prefill shape. */
         const uint32_t default_nsg = n_tokens == 2u && ds4_gpu_device_name_contains("M3 Ultra") ? 8u : 1u;
-        const uint32_t nsg = n_tokens <= 2u ?
-            (uint32_t)ds4_gpu_env_u64("DS4_QWEN4_GDN_NSG", default_nsg, 1u, 8u) :
+        const uint32_t prefill_default_nsg =
             n_tokens >= 8192u && n_k_head == 16u && n_v_head == 48u &&
             ds4_gpu_device_name_contains("M3 Ultra") ? 4u : 1u;
+        const uint32_t nsg = n_tokens <= 2u ?
+            (uint32_t)ds4_gpu_env_u64("DS4_QWEN4_GDN_NSG", default_nsg, 1u, 8u) :
+            (uint32_t)ds4_gpu_env_u64("DS4_QWEN4_GDN_PREFILL_NSG", prefill_default_nsg, 1u, 8u);
         return qwen4_dispatch(QWEN4_K_GDN_SCAN_R4, &args, sizeof(args), bd, 6,
                               MTLSizeMake((head_dim + 4u * nsg - 1u) / (4u * nsg), n_v_head, 1),
                               MTLSizeMake(32u * nsg, 1, 1), 0);

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -5395,6 +5395,17 @@ static ds4_gpu_mv_dispatch ds4_gpu_make_q8_0_mv_dispatch(void) {
     };
 }
 
+/* Single-token F16/F32 matvecs with few output rows (the Qwen hyper-connection
+ * low-rank down projections and routers) launch one row per SIMD group on M5,
+ * where two-row tiles leave most of the 40 cores idle.  The per-row K walk,
+ * simdgroup count and reduction tree are unchanged.  DS4_METAL_PLAIN_MV_NR0
+ * forces 1 or 2 rows on any device. */
+static bool ds4_gpu_plain_mv_single_row(uint64_t out_dim) {
+    const uint64_t override = ds4_gpu_env_u64("DS4_METAL_PLAIN_MV_NR0", 0u, 0u, 2u);
+    if (override) return override == 1u;
+    return out_dim <= 1024u && ds4_gpu_device_is_m5_apple_silicon();
+}
+
 static ds4_gpu_mv_dispatch ds4_gpu_make_plain_mv_dispatch(
         uint64_t in_dim,
         int      f32_weights) {
@@ -20913,6 +20924,12 @@ int ds4_gpu_matmul_f16_tensor(
                 mv_dispatch.nr0 = 4;
                 mv_dispatch.smem = 32u * 4u * sizeof(float);
             }
+            /* One row per SIMD group doubles the threadgroup count of narrow
+             * projections; every row keeps its K walk and reduction tree. */
+            if (ds4_gpu_plain_mv_single_row(out_dim)) {
+                mv_dispatch.nr0 = 1;
+                mv_dispatch.smem = 32u * sizeof(float);
+            }
             mv_args.nr0 = mv_dispatch.nr0;
             id<MTLComputePipelineState> pipeline =
                 ds4_gpu_get_mul_mv_pipeline(mv_dispatch.function_name, mv_dispatch.nsg);
@@ -21771,6 +21788,10 @@ int ds4_gpu_matmul_f32_tensor(
         if (n_tok == 1) {
             ds4_gpu_q8_0_matvec_args mv_args = ds4_gpu_make_f32_mv_args(in_dim, out_dim, 1);
             ds4_gpu_mv_dispatch mv_dispatch = ds4_gpu_make_plain_mv_dispatch(in_dim, 1);
+            if (ds4_gpu_plain_mv_single_row(out_dim)) {
+                mv_dispatch.nr0 = 1;
+                mv_dispatch.smem = 32u * sizeof(float);
+            }
             mv_args.nr0 = mv_dispatch.nr0;
             id<MTLComputePipelineState> pipeline =
                 ds4_gpu_get_mul_mv_pipeline(mv_dispatch.function_name, mv_dispatch.nsg);

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -48616,8 +48616,13 @@ int ds4_gpu_qwen4_gdn_front_tensor(
     } else {
         b[10] = b[1];
     }
+    /* One threadgroup per key head: simdgroups 0/1 normalize, the rest take
+     * the alpha/beta rows, and every channel's conv stays on one thread, so
+     * the thread count only spreads the conv wider.  M5 measured 1024. */
+    const uint64_t nth = ds4_gpu_env_u64("DS4_QWEN4_GDN_FRONT_THREADS",
+                                         ds4_gpu_device_is_m5_apple_silicon() ? 1024u : 256u, 96u, 1024u);
     return qwen4_dispatch(QWEN4_K_GDN_FRONT, &args, sizeof(args), b, 11,
-                          MTLSizeMake(n_k_head, 1, 1), MTLSizeMake(256, 1, 1), 0);
+                          MTLSizeMake(n_k_head, 1, 1), MTLSizeMake((NSUInteger)(nth / 32u * 32u), 1, 1), 0);
 }
 
 int ds4_gpu_qwen4_multi_gemv_tensor(

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -47529,8 +47529,21 @@ static const char *const qwen4_kernel_names[QWEN4_K_COUNT] = {
 typedef struct {
     uint32_t n_tokens, n_slots, n_out, in_dim, out_rows, weight_type, row_bytes, list_cap;
     uint64_t expert_bytes;
-    uint32_t n_expert, tiles_per_launch, tail_base, pad1;
+    uint32_t n_expert, tiles_per_launch, tail_base, expert_major;
 } qwen4_moe_mm_args;
+
+/* Expert-major tile order (DS4_QWEN4_MOE_MM_ORDER=0 restores the tile-major
+ * grid): consecutive threadgroups share a token tile and one expert's rows
+ * stay cache-resident across its tiles. */
+static uint32_t qwen4_moe_mm_expert_major(void) {
+    const int override = ds4_gpu_env_bool("DS4_QWEN4_MOE_MM_ORDER");
+    return override >= 0 ? (uint32_t)override : ds4_gpu_device_is_m5_apple_silicon() ? 1u : 0u;
+}
+
+static MTLSize qwen4_moe_mm_grid(uint32_t row_blocks, uint32_t n_expert, uint32_t tiles, uint32_t expert_major) {
+    return expert_major ? MTLSizeMake((NSUInteger)row_blocks * tiles, n_expert, 1)
+                        : MTLSizeMake(row_blocks, n_expert, tiles);
+}
 
 static id<MTLComputePipelineState> g_qwen4_pipelines[QWEN4_K_COUNT];
 #define QWEN4_ATTN_NSG 4
@@ -48450,7 +48463,7 @@ int ds4_gpu_qwen4_moe_mm_mid_tensor(
     const int kernel = nt == 1u ? QWEN4_K_MOE_MM_MID_NT1 :
                        nt == 2u ? QWEN4_K_MOE_MM_MID_NT2 : QWEN4_K_MOE_MM_MID;
     qwen4_moe_mm_args args = { n_tokens, n_slots, n_out, in_dim, ff_dim, weight_type, row_bytes, list_cap,
-                               expert_bytes, n_expert, tiles, 0, 0 };
+                               expert_bytes, n_expert, tiles, 0, qwen4_moe_mm_expert_major() };
     const bool tails = qwen4_moe_mm_tails(weight_type, nt);
     if (tails) args.tail_base = nt * 8u;
     qwen4_bind b[6];
@@ -48466,7 +48479,8 @@ int ds4_gpu_qwen4_moe_mm_mid_tensor(
         return 0;
     }
     if (!qwen4_dispatch(kernel, &args, sizeof(args), b, 6,
-                          MTLSizeMake((ff_dim + 31u) / 32u, n_expert, tiles), MTLSizeMake(128, 1, 1), 0)) return 0;
+                          qwen4_moe_mm_grid((ff_dim + 31u) / 32u, n_expert, tiles, args.expert_major),
+                          MTLSizeMake(128, 1, 1), 0)) return 0;
     if (tails) {
         const MTLSize tail_grid = MTLSizeMake((ff_dim + 31u) / 32u, n_expert, 1);
         if (!qwen4_dispatch(QWEN4_K_MOE_MM_MID_NT1, &args, sizeof(args), b, 6, tail_grid, MTLSizeMake(128, 1, 1), 0)) return 0;
@@ -48489,7 +48503,7 @@ int ds4_gpu_qwen4_moe_mm_down_tensor(
                        nt == 2u ? QWEN4_K_MOE_MM_DOWN_NT2 :
                        nt == 8u ? QWEN4_K_MOE_MM_DOWN_NT8 : QWEN4_K_MOE_MM_DOWN;
     qwen4_moe_mm_args args = { n_tokens, n_slots, n_out, ff_dim, out_dim, weight_type, row_bytes, list_cap,
-                               expert_bytes, n_expert, tiles, 0, 0 };
+                               expert_bytes, n_expert, tiles, 0, qwen4_moe_mm_expert_major() };
     const bool tails = qwen4_moe_mm_tails(weight_type, nt);
     if (tails) args.tail_base = nt * 8u;
     qwen4_bind b[5];
@@ -48504,7 +48518,8 @@ int ds4_gpu_qwen4_moe_mm_down_tensor(
         return 0;
     }
     if (!qwen4_dispatch(kernel, &args, sizeof(args), b, 5,
-                          MTLSizeMake((out_dim + 31u) / 32u, n_expert, tiles), MTLSizeMake(128, 1, 1), 0)) return 0;
+                          qwen4_moe_mm_grid((out_dim + 31u) / 32u, n_expert, tiles, args.expert_major),
+                          MTLSizeMake(128, 1, 1), 0)) return 0;
     if (tails) {
         const MTLSize tail_grid = MTLSizeMake((out_dim + 31u) / 32u, n_expert, 1);
         if (!qwen4_dispatch(QWEN4_K_MOE_MM_DOWN_NT1, &args, sizeof(args), b, 5, tail_grid, MTLSizeMake(128, 1, 1), 0)) return 0;

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -47421,6 +47421,7 @@ enum {
     QWEN4_K_ATTN_PREP,
     QWEN4_K_IDX_BLOCK_KEY,
     QWEN4_K_IDX_SCORE,
+    QWEN4_K_IDX_SCORE_VEC,
     QWEN4_K_IDX_SELECT,
     QWEN4_K_IDX_SCORE_MM,
     QWEN4_K_IDX_EXPAND,
@@ -47430,6 +47431,8 @@ enum {
     QWEN4_K_ATTN_MERGE_NPT8,
     QWEN4_K_ATTN_MERGE_NPT4,
     QWEN4_K_ATTN_MERGE_NPT1,
+    QWEN4_K_ATTN_MERGE_WIDE_NPT8,
+    QWEN4_K_ATTN_MERGE_WIDE_NPT4,
     QWEN4_K_ATTN_MM,
     QWEN4_K_MOE_MID,
     QWEN4_K_MOE_MID_Q4K,
@@ -47487,6 +47490,7 @@ static const char *const qwen4_kernel_names[QWEN4_K_COUNT] = {
     "kernel_qwen4_attn_prep",
     "kernel_qwen4_idx_block_key",
     "kernel_qwen4_idx_score",
+    "kernel_qwen4_idx_score_vec",
     "kernel_qwen4_idx_select",
     "kernel_qwen4_idx_score_mm",
     "kernel_qwen4_idx_expand",
@@ -47496,6 +47500,8 @@ static const char *const qwen4_kernel_names[QWEN4_K_COUNT] = {
     "kernel_qwen4_attn_merge_npt8",
     "kernel_qwen4_attn_merge_npt4",
     "kernel_qwen4_attn_merge_npt1",
+    "kernel_qwen4_attn_merge_wide_npt8",
+    "kernel_qwen4_attn_merge_wide_npt4",
     "kernel_qwen4_attn_mm",
     "kernel_qwen4_moe_mid",
     "kernel_qwen4_moe_mid_q4k",
@@ -48148,7 +48154,12 @@ int ds4_gpu_qwen4_idx_score_tensor(
         return qwen4_dispatch(QWEN4_K_IDX_SCORE_MM, &args, sizeof(args), b, 3,
                               MTLSizeMake((n_blocks + 63) / 64, (n_tokens + 15) / 16, 1), MTLSizeMake(128, 1, 1), 0);
     }
-    return qwen4_dispatch(QWEN4_K_IDX_SCORE, &args, sizeof(args), b, 3,
+    /* staged queries and vector key loads; measured on M5, other devices
+     * keep the scalar scorer */
+    const int vec_override = ds4_gpu_env_bool("DS4_QWEN4_IDX_SCORE_VEC");
+    const bool vec = n_idx_head * idx_dim <= 512u && (idx_dim & 3u) == 0u &&
+        (vec_override >= 0 ? vec_override != 0 : ds4_gpu_device_is_m5_apple_silicon());
+    return qwen4_dispatch(vec ? QWEN4_K_IDX_SCORE_VEC : QWEN4_K_IDX_SCORE, &args, sizeof(args), b, 3,
                           MTLSizeMake((n_blocks + 127) / 128, n_tokens, 1), MTLSizeMake(128, 1, 1), 0);
 }
 
@@ -48257,6 +48268,16 @@ int ds4_gpu_qwen4_attn_decode_tensor(
     }
     if (n_splits == 1) return 1;
     qwen4_bind mb[3] = { b[7], b[1], b[6] };
+    /* One thread per dim merges the same split chain with eight times the
+     * threads; measured on M5, other devices keep the simdgroup merge. */
+    const int wide_override = ds4_gpu_env_bool("DS4_QWEN4_ATTN_MERGE_WIDE");
+    const bool wide = head_dim >= 128u &&
+        (wide_override >= 0 ? wide_override != 0 : ds4_gpu_device_is_m5_apple_silicon());
+    if (wide) {
+        return qwen4_dispatch(head_dim == 256u ? QWEN4_K_ATTN_MERGE_WIDE_NPT8 : QWEN4_K_ATTN_MERGE_WIDE_NPT4,
+                              &args, sizeof(args), mb, 3,
+                              MTLSizeMake(n_head, n_tokens, 1), MTLSizeMake(head_dim, 1, 1), 0);
+    }
     return qwen4_dispatch(km, &args, sizeof(args), mb, 3,
                           MTLSizeMake(n_head, n_tokens, 1), MTLSizeMake(32, 1, 1), 0);
 }

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -47523,10 +47523,12 @@ typedef struct {
 
 static bool qwen4_moe_mv_specialize(uint32_t type) {
     /* Constant quantization and logical width remove the generic decode
-     * branches. Keep the original per-lane reduction order and padded stride. */
+     * branches. Keep the original per-lane reduction order and padded stride.
+     * M3 Ultra measured the low-bit types; M5 measured MXFP4 down rows. */
     const int override = ds4_gpu_env_bool("DS4_QWEN4_MOE_MV_SPECIALIZE");
     return override >= 0 ? override != 0 :
-        (type == 16u || type == 10u) && ds4_gpu_device_name_contains("M3 Ultra");
+        ((type == 16u || type == 10u) && ds4_gpu_device_name_contains("M3 Ultra")) ||
+        (type == 39u && ds4_gpu_device_is_m5_apple_silicon());
 }
 
 static uint32_t qwen4_moe_mv_rows(void) {
@@ -47534,7 +47536,11 @@ static uint32_t qwen4_moe_mv_rows(void) {
 }
 
 static uint32_t qwen4_moe_mv_groups(uint32_t type) {
-    const uint32_t default_nsg = type == 10u && ds4_gpu_device_name_contains("M3 Ultra") ? 16u : 8u;
+    /* Sixteen SIMD groups per threadgroup measured best for Q2_K on M3 Ultra
+     * and for MXFP4 on M5; each group keeps its own rows and lane order. */
+    const uint32_t default_nsg =
+        (type == 10u && ds4_gpu_device_name_contains("M3 Ultra")) ||
+        (type == 39u && ds4_gpu_device_is_m5_apple_silicon()) ? 16u : 8u;
     return (uint32_t)ds4_gpu_env_u64("DS4_QWEN4_MOE_MV_NSG", default_nsg, 1u, 16u);
 }
 
@@ -48256,15 +48262,17 @@ int ds4_gpu_qwen4_moe_mid_tensor(
     const bool q4k = weight_type == 12u && getenv("DS4_QWEN4_NO_Q4K_MID") == NULL;
     const bool m3_ultra = q4k && ds4_gpu_device_name_contains("M3 Ultra");
     /* One row per SIMD group improves both single-token decode and the
-     * two-token MTP verifier on M3 Ultra without changing dot-product order. */
-    const uint32_t default_nr = m3_ultra && n_tokens <= 2u ? 1u : 2u;
+     * two-token MTP verifier on M3 Ultra without changing dot-product order.
+     * M5 measured the single-token case with four groups per threadgroup. */
+    const bool m5_single = q4k && n_tokens == 1u && ds4_gpu_device_is_m5_apple_silicon();
+    const uint32_t default_nr = (m3_ultra && n_tokens <= 2u) || m5_single ? 1u : 2u;
     const bool specialize = !q4k && qwen4_moe_mv_specialize(weight_type);
     const uint64_t nr_env = q4k ?
         ds4_gpu_env_u64("DS4_QWEN4_Q4K_MID_NR", default_nr, 1u, UINT64_MAX) :
         (specialize ? qwen4_moe_mv_rows() : 2u);
     const uint32_t nr = nr_env >= 1u && nr_env <= (q4k ? 2u : 4u) ? (uint32_t)nr_env : default_nr;
     /* NR2 without an NSG override restores the former ordered dispatch. */
-    const uint32_t default_nsg = m3_ultra && nr == 1u ? 8u : 2u;
+    const uint32_t default_nsg = nr != 1u ? 2u : m3_ultra ? 8u : m5_single ? 4u : 2u;
     const uint32_t nsg = q4k ?
         (uint32_t)ds4_gpu_env_u64("DS4_QWEN4_Q4K_MID_NSG", default_nsg, 1u, 8u) :
         (specialize ? qwen4_moe_mv_groups(weight_type) : 4u);

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -47423,6 +47423,7 @@ enum {
     QWEN4_K_IDX_SCORE,
     QWEN4_K_IDX_SCORE_VEC,
     QWEN4_K_IDX_SELECT,
+    QWEN4_K_IDX_SELECT_PRE,
     QWEN4_K_IDX_SCORE_MM,
     QWEN4_K_IDX_EXPAND,
     QWEN4_K_ATTN_DECODE_NPT8,
@@ -47492,6 +47493,7 @@ static const char *const qwen4_kernel_names[QWEN4_K_COUNT] = {
     "kernel_qwen4_idx_score",
     "kernel_qwen4_idx_score_vec",
     "kernel_qwen4_idx_select",
+    "kernel_qwen4_idx_select_pre",
     "kernel_qwen4_idx_score_mm",
     "kernel_qwen4_idx_expand",
     "kernel_qwen4_attn_decode_npt8",
@@ -48138,12 +48140,12 @@ int ds4_gpu_qwen4_idx_block_key_tensor(
 }
 
 int ds4_gpu_qwen4_idx_score_tensor(
-        ds4_gpu_tensor *score, const ds4_gpu_tensor *iq, const ds4_gpu_tensor *block_key,
+        ds4_gpu_tensor *score, ds4_gpu_tensor *tile_max, const ds4_gpu_tensor *iq, const ds4_gpu_tensor *block_key,
         uint32_t n_tokens, uint32_t n_blocks, uint32_t n_idx_head, uint32_t idx_dim,
         uint32_t pos0, uint32_t ratio) {
     struct { uint32_t n_tokens, n_blocks, n_idx_head, idx_dim, pos0, ratio, pad0, pad1; } args =
         { n_tokens, n_blocks, n_idx_head, idx_dim, pos0, ratio, 0, 0 };
-    qwen4_bind b[3];
+    qwen4_bind b[4];
     if (n_tokens == 0 || n_blocks == 0 || ratio == 0 ||
         !qwen4_bind_tensor(&b[0], iq, (uint64_t)n_tokens * n_idx_head * idx_dim * sizeof(float), "indexer q") ||
         !qwen4_bind_tensor(&b[1], block_key, (uint64_t)n_blocks * idx_dim * 2u, "block keys") ||
@@ -48154,24 +48156,45 @@ int ds4_gpu_qwen4_idx_score_tensor(
         return qwen4_dispatch(QWEN4_K_IDX_SCORE_MM, &args, sizeof(args), b, 3,
                               MTLSizeMake((n_blocks + 63) / 64, (n_tokens + 15) / 16, 1), MTLSizeMake(128, 1, 1), 0);
     }
-    /* staged queries and vector key loads; measured on M5, other devices
-     * keep the scalar scorer */
+    /* staged queries and vector key loads, plus the tile maxima the
+     * prefiltered selector needs; measured on M5, other devices keep the
+     * scalar scorer */
     const int vec_override = ds4_gpu_env_bool("DS4_QWEN4_IDX_SCORE_VEC");
-    const bool vec = n_idx_head * idx_dim <= 512u && (idx_dim & 3u) == 0u &&
+    const bool vec = tile_max && n_idx_head * idx_dim <= 512u && (idx_dim & 3u) == 0u &&
         (vec_override >= 0 ? vec_override != 0 : ds4_gpu_device_is_m5_apple_silicon());
-    return qwen4_dispatch(vec ? QWEN4_K_IDX_SCORE_VEC : QWEN4_K_IDX_SCORE, &args, sizeof(args), b, 3,
+    if (vec) {
+        if (!qwen4_bind_tensor(&b[3], tile_max, (uint64_t)n_tokens * ((n_blocks + 7u) / 8u) * sizeof(uint32_t),
+                               "indexer tile maxima")) return 0;
+        return qwen4_dispatch(QWEN4_K_IDX_SCORE_VEC, &args, sizeof(args), b, 4,
+                              MTLSizeMake((n_blocks + 127) / 128, n_tokens, 1), MTLSizeMake(128, 1, 1), 0);
+    }
+    return qwen4_dispatch(QWEN4_K_IDX_SCORE, &args, sizeof(args), b, 3,
                           MTLSizeMake((n_blocks + 127) / 128, n_tokens, 1), MTLSizeMake(128, 1, 1), 0);
 }
 
 int ds4_gpu_qwen4_idx_select_tensor(
-        ds4_gpu_tensor *sel, const ds4_gpu_tensor *score, uint32_t n_blocks, uint32_t n_tokens, uint32_t top_k) {
+        ds4_gpu_tensor *sel, const ds4_gpu_tensor *score, const ds4_gpu_tensor *tile_max,
+        uint32_t n_blocks, uint32_t n_tokens, uint32_t top_k) {
     struct { uint32_t n_tokens, n_blocks, top_k, pad0; } args = { n_tokens, n_blocks, top_k, 0 };
-    qwen4_bind b[2];
+    qwen4_bind b[3];
     if (n_tokens == 0 || top_k == 0 || top_k > n_blocks ||
         !qwen4_bind_tensor(&b[0], score, (uint64_t)n_tokens * n_blocks * sizeof(float), "indexer scores") ||
-        !qwen4_bind_tensor(&b[1], sel, (uint64_t)n_tokens * top_k * sizeof(int32_t), "selected blocks")) {
+        !qwen4_bind_tensor(&b[2], sel, (uint64_t)n_tokens * top_k * sizeof(int32_t), "selected blocks")) {
         return 0;
     }
+    /* Long rows: bound the k-th score by the k-th tile maximum and select
+     * over the surviving tiles in threadgroup memory (exact; see the kernel).
+     * The scorer that emits tile maxima only runs for decode batches. */
+    const int pre_override = ds4_gpu_env_bool("DS4_QWEN4_IDX_PREFILTER");
+    const bool pre = tile_max && n_blocks > 8u * top_k &&
+        (pre_override >= 0 ? pre_override != 0 : ds4_gpu_device_is_m5_apple_silicon());
+    if (pre) {
+        if (!qwen4_bind_tensor(&b[1], tile_max, (uint64_t)n_tokens * ((n_blocks + 7u) / 8u) * sizeof(uint32_t),
+                               "indexer tile maxima")) return 0;
+        return qwen4_dispatch(QWEN4_K_IDX_SELECT_PRE, &args, sizeof(args), b, 3,
+                              MTLSizeMake(n_tokens, 1, 1), MTLSizeMake(1024, 1, 1), 0);
+    }
+    b[1] = b[2];
     return qwen4_dispatch(QWEN4_K_IDX_SELECT, &args, sizeof(args), b, 2,
                           MTLSizeMake(n_tokens, 1, 1), MTLSizeMake(1024, 1, 1), 0);
 }

--- a/ds4_metal.m
+++ b/ds4_metal.m
@@ -47574,11 +47574,12 @@ static int qwen4_dispatch(int kernel, const void *args, size_t args_len,
             }
         } else if (kernel >= QWEN4_K_MOE_MM_MID && kernel <= QWEN4_K_MOE_MM_DOWN_NT8) {
             /* Keep each quantization's dequantizer constant through the K
-             * loop. M3 Ultra has balanced full-model measurements; other
-             * devices can opt in, and zero restores the generic kernel. */
+             * loop. M3 Ultra and M5 have balanced full-model measurements;
+             * other devices can opt in, and zero restores the generic kernel. */
             const int override = ds4_gpu_env_bool("DS4_QWEN4_MOE_MM_SPECIALIZE");
             const bool specialize = override >= 0 ? override != 0 :
-                ds4_gpu_device_name_contains("M3 Ultra");
+                ds4_gpu_device_name_contains("M3 Ultra") ||
+                ds4_gpu_device_is_m5_apple_silicon();
             const uint32_t type = specialize ?
                 ((const qwen4_moe_mm_args *)args)->weight_type : 0u;
             if (type >= 40u) return 0;
@@ -47727,7 +47728,7 @@ int ds4_gpu_qwen4_hc_norm_tensor(
             reuse = true;
         } else if (reuse_env == NULL || strcmp(reuse_env, "0") != 0) {
             reuse = n_tokens >= 8192u && n_embd == 2560u && n_hc == 4u && n_inject == 4u &&
-                    ds4_gpu_device_name_contains("M3 Ultra");
+                    (ds4_gpu_device_name_contains("M3 Ultra") || ds4_gpu_device_is_m5_apple_silicon());
         }
     }
     const int kernel = reuse
@@ -48376,13 +48377,17 @@ int ds4_gpu_qwen4_moe_build_lists_tensor(
                           MTLSizeMake(1, 1, 1), MTLSizeMake(512, 1, 1), 0);
 }
 
-static uint32_t qwen4_moe_mm_tiles(uint32_t n_tokens, const char *env_name) {
+static uint32_t qwen4_moe_mm_tiles(uint32_t n_tokens, bool mid) {
     uint32_t tiles = (n_tokens + 31u) / 32u;
-    /* Spread large routed batches over more independent tiles on M3 Ultra.
+    /* Spread large routed batches over more independent tiles on M3 Ultra
+     * (gate/up and down) and on M5 (gate/up; the down tiles measured flat).
      * Each tile keeps the same K loop and accumulation order. */
-    const uint32_t default_cap = ds4_gpu_device_name_contains("M3 Ultra") ?
+    const bool spread = ds4_gpu_device_name_contains("M3 Ultra") ||
+                        (mid && ds4_gpu_device_is_m5_apple_silicon());
+    const uint32_t default_cap = spread ?
         (n_tokens >= 8192u ? 32u : n_tokens >= 4096u ? 16u : 8u) : 8u;
-    const uint32_t cap = (uint32_t)ds4_gpu_env_u64(env_name, default_cap, 1u, 32u);
+    const uint32_t cap = (uint32_t)ds4_gpu_env_u64(
+        mid ? "DS4_QWEN4_MOE_MID_TILES" : "DS4_QWEN4_MOE_DOWN_TILES", default_cap, 1u, 32u);
     return tiles > cap ? cap : tiles;
 }
 
@@ -48404,9 +48409,12 @@ static uint32_t qwen4_moe_mm_nt(uint32_t n_tokens, uint32_t type, const char *en
 }
 
 static bool qwen4_moe_mm_tails(uint32_t type, uint32_t nt) {
+    /* Remainder tiles measured on M3 Ultra for the low-bit experts and on M5
+     * for Q4_K gate/up with MXFP4 down. */
     const int override = ds4_gpu_env_bool("DS4_QWEN4_MOE_TAILS");
     return nt > 1u && (override >= 0 ? override != 0 :
-        (type == 16u || type == 10u) && ds4_gpu_device_name_contains("M3 Ultra"));
+        ((type == 16u || type == 10u) && ds4_gpu_device_name_contains("M3 Ultra")) ||
+        ((type == 12u || type == 39u) && ds4_gpu_device_is_m5_apple_silicon()));
 }
 
 int ds4_gpu_qwen4_moe_mm_mid_tensor(
@@ -48416,7 +48424,7 @@ int ds4_gpu_qwen4_moe_mm_mid_tensor(
         uint32_t in_dim, uint32_t ff_dim, uint32_t list_cap) {
     const uint32_t row_bytes = qwen4_expert_row_bytes(weight_type, in_dim);
     const uint64_t expert_bytes = (uint64_t)row_bytes * ff_dim;
-    const uint32_t tiles = qwen4_moe_mm_tiles(n_tokens, "DS4_QWEN4_MOE_MID_TILES");
+    const uint32_t tiles = qwen4_moe_mm_tiles(n_tokens, true);
     const uint32_t nt = qwen4_moe_mm_nt(n_tokens, weight_type, "DS4_QWEN4_MOE_MID_NT");
     const int kernel = nt == 1u ? QWEN4_K_MOE_MM_MID_NT1 :
                        nt == 2u ? QWEN4_K_MOE_MM_MID_NT2 : QWEN4_K_MOE_MM_MID;
@@ -48454,7 +48462,7 @@ int ds4_gpu_qwen4_moe_mm_down_tensor(
     const uint32_t weight_dim = weight_type == 10u ? (ff_dim + 255u) / 256u * 256u : ff_dim;
     const uint32_t row_bytes = qwen4_expert_row_bytes(weight_type, weight_dim);
     const uint64_t expert_bytes = (uint64_t)row_bytes * out_dim;
-    const uint32_t tiles = qwen4_moe_mm_tiles(n_tokens, "DS4_QWEN4_MOE_DOWN_TILES");
+    const uint32_t tiles = qwen4_moe_mm_tiles(n_tokens, false);
     const uint32_t nt = qwen4_moe_mm_nt(n_tokens, weight_type, "DS4_QWEN4_MOE_DOWN_NT");
     const int kernel = nt == 1u ? QWEN4_K_MOE_MM_DOWN_NT1 :
                        nt == 2u ? QWEN4_K_MOE_MM_DOWN_NT2 :

--- a/metal/dense.metal
+++ b/metal/dense.metal
@@ -1336,6 +1336,7 @@ void kernel_mul_mv_t_t_4_disp(
         ushort tiisg,
         ushort sgitg) {
     switch (args.nr0) {
+        case 1: kernel_mul_mv_t_t_4_impl<T0, T04, T1, T14, 1, args_t>(args, src0, src1, dst, shmem, tgpig, tiisg, sgitg); break;
         case 2: kernel_mul_mv_t_t_4_impl<T0, T04, T1, T14, 2, args_t>(args, src0, src1, dst, shmem, tgpig, tiisg, sgitg); break;
         case 4: kernel_mul_mv_t_t_4_impl<T0, T04, T1, T14, 4, args_t>(args, src0, src1, dst, shmem, tgpig, tiisg, sgitg); break;
     };

--- a/metal/qwen4.metal
+++ b/metal/qwen4.metal
@@ -1147,9 +1147,11 @@ kernel void kernel_qwen4_idx_score_vec(
         device const float *iq,          /* [T][Hi*Di] */
         device const half  *block_key,   /* [n_blocks][Di] */
         device float       *score,       /* [T][n_blocks] */
+        device uint        *tile_max,    /* [T][(n_blocks+7)/8] score keys */
         uint3 tgpig [[threadgroup_position_in_grid]],
         ushort tid [[thread_index_in_threadgroup]],
-        ushort3 ntg [[threads_per_threadgroup]]) {
+        ushort3 ntg [[threads_per_threadgroup]],
+        ushort tiisg [[thread_index_in_simdgroup]]) {
     threadgroup float qs[4 * 128];
     const uint tok = tgpig.y;
     const uint Di = args.idx_dim;
@@ -1159,27 +1161,35 @@ kernel void kernel_qwen4_idx_score_vec(
     for (uint i = tid; i < nq; i += ntg.x) qs[i] = q[i];
     threadgroup_barrier(mem_flags::mem_threadgroup);
     const uint b = tgpig.x * ntg.x + tid;
-    if (b >= args.n_blocks) return;
     const uint visible = (args.pos0 + tok + 1) / args.ratio;
-    if (b >= visible) {
-        score[(uint64_t)tok * args.n_blocks + b] = -3.0e38f;
-        return;
-    }
-    device const half4 *key = (device const half4 *)(block_key + (uint64_t)b * Di);
-    float sum = 0.0f;
-    for (uint h = 0; h < args.n_idx_head; h++) {
-        const threadgroup float *qh = qs + h * Di;
-        float dot = 0.0f;
-        for (uint d = 0; d < Di; d += 4) {
-            const half4 k = key[d >> 2];
-            dot += qh[d] * (float)k.x;
-            dot += qh[d + 1] * (float)k.y;
-            dot += qh[d + 2] * (float)k.z;
-            dot += qh[d + 3] * (float)k.w;
+    const bool live = b < args.n_blocks && b < visible;
+    float sum = -3.0e38f;
+    if (live) {
+        device const half4 *key = (device const half4 *)(block_key + (uint64_t)b * Di);
+        sum = 0.0f;
+        for (uint h = 0; h < args.n_idx_head; h++) {
+            const threadgroup float *qh = qs + h * Di;
+            float dot = 0.0f;
+            for (uint d = 0; d < Di; d += 4) {
+                const half4 k = key[d >> 2];
+                dot += qh[d] * (float)k.x;
+                dot += qh[d + 1] * (float)k.y;
+                dot += qh[d + 2] * (float)k.z;
+                dot += qh[d + 3] * (float)k.w;
+            }
+            sum += max(dot, 0.0f);
         }
-        sum += max(dot, 0.0f);
     }
-    score[(uint64_t)tok * args.n_blocks + b] = sum;
+    if (b < args.n_blocks) score[(uint64_t)tok * args.n_blocks + b] = sum;
+    /* the selector's key of this block (-inf and missing blocks map to 0),
+     * reduced over the aligned eight-lane group; every lane joins the
+     * shuffles */
+    uint key = live ? as_type<uint>(max(sum, 0.0f)) : 0u;
+    key = max(key, simd_shuffle_xor(key, 1));
+    key = max(key, simd_shuffle_xor(key, 2));
+    key = max(key, simd_shuffle_xor(key, 4));
+    const uint n_tiles = (args.n_blocks + 7u) / 8u;
+    if ((tiisg & 7u) == 0u && (b >> 3) < n_tiles) tile_max[(uint64_t)tok * n_tiles + (b >> 3)] = key;
 }
 
 /* Matrix-unit block scorer for 4 heads x 128 dims: a threadgroup scores 16
@@ -1348,6 +1358,180 @@ kernel void kernel_qwen4_idx_select(
             if (key > prefix) out[r_gt++] = (int32_t)(b + u);
             else if (key == prefix) { if (r_eq < need) out[eq_base + r_eq] = (int32_t)(b + u); r_eq++; }
         }
+    }
+}
+
+#define QWEN4_IDX_PRE_TILES 512   /* surviving tiles held in threadgroup memory */
+#define QWEN4_IDX_PRE_MAX_TILES 8192
+
+/* Key of entry e of the compact set: tile tiles[e>>3], block e&7. */
+static inline uint qwen4_idx_pre_block(threadgroup const ushort *tiles, uint e) {
+    return (uint)tiles[e >> 3] * 8u + (e & 7u);
+}
+
+/* Radix pass shared by the tile bound and the compact select: the k-th
+ * largest key among n keys, same digit order and suffix-sum ranking as
+ * kernel_qwen4_idx_select.  MODE 0 reads tile maxima, MODE 1 the compact
+ * keys (entries past the last block are skipped), MODE 2 a full score row. */
+template <int MODE>
+static inline void qwen4_idx_radix(device const uint *tm, threadgroup const uint *keys,
+                                   threadgroup const ushort *tiles, device const float *row,
+                                   uint n_blocks, uint n, uint k, uint nth, ushort tid, ushort sgitg, ushort tiisg,
+                                   threadgroup atomic_uint *hist, threadgroup uint *scan, threadgroup uint *found,
+                                   thread uint &prefix_out, thread uint &need_out) {
+    uint prefix = 0, need = k;
+    for (uint pass = 0; pass < 4; pass++) {
+        const uint shift = 24 - 8 * pass;
+        const uint mask_hi = pass == 0 ? 0u : (0xFFFFFFFFu << (shift + 8));
+        for (uint i = tid; i < 256; i += nth) atomic_store_explicit(&hist[i], 0u, memory_order_relaxed);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint e = tid; e < n; e += nth) {
+            uint key;
+            if (MODE == 0) key = tm[e];
+            else if (MODE == 1) { if (qwen4_idx_pre_block(tiles, e) >= n_blocks) continue; key = keys[e]; }
+            else key = as_type<uint>(max(row[e], 0.0f));
+            if ((key & mask_hi) == prefix) atomic_fetch_add_explicit(&hist[(key >> shift) & 0xFFu], 1u, memory_order_relaxed);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        const uint c = tid < 256 ? atomic_load_explicit(&hist[255 - tid], memory_order_relaxed) : 0u;
+        const uint p = simd_prefix_inclusive_sum(c);
+        if (tiisg == 31 && sgitg < 8) scan[sgitg] = p;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (tid < 256) {
+            uint above = p - c;
+            for (uint g = 0; g < sgitg; g++) above += scan[g];
+            if (above < need && above + c >= need) {
+                found[0] = prefix | ((255u - tid) << shift);
+                found[1] = need - above;
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        prefix = found[0]; need = found[1];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    prefix_out = prefix;
+    need_out = need;
+}
+
+/* Prefiltered top-k for one or two decode tokens (see the host comment):
+ * tau = k-th largest tile maximum, survivors = tiles with maximum >= tau,
+ * then the full-row radix select and gather over the survivors' blocks in
+ * threadgroup memory.  Rows with more than QWEN4_IDX_PRE_TILES survivors or
+ * more than QWEN4_IDX_PRE_MAX_TILES tiles run the full-row algorithm. */
+kernel void kernel_qwen4_idx_select_pre(
+        constant ds4_metal_args_qwen4_idx_select & args,
+        device const float *score,     /* [T][n_blocks] */
+        device const uint  *tile_max,  /* [T][n_tiles] */
+        device int32_t     *sel,       /* [T][top_k] */
+        uint3 tgpig [[threadgroup_position_in_grid]],
+        ushort tid [[thread_index_in_threadgroup]],
+        ushort3 ntg [[threads_per_threadgroup]],
+        ushort sgitg [[simdgroup_index_in_threadgroup]],
+        ushort tiisg [[thread_index_in_simdgroup]]) {
+    const uint tok = tgpig.x;
+    if (tok >= args.n_tokens) return;
+    const uint nth = ntg.x;
+    const uint n = args.n_blocks;
+    const uint n_tiles = (n + 7u) / 8u;
+    device const float *row = score + (uint64_t)tok * n;
+    device const uint *tm = tile_max + (uint64_t)tok * n_tiles;
+    device int32_t *out = sel + (uint64_t)tok * args.top_k;
+    threadgroup atomic_uint hist[256];
+    threadgroup uint scan[32];
+    threadgroup uint found[2];
+    threadgroup uint keys[QWEN4_IDX_PRE_TILES * 8];
+    threadgroup ushort tiles[QWEN4_IDX_PRE_TILES];
+    threadgroup uint total_surv;
+
+    /* 1. tau: the k-th largest tile maximum (every tile survives when there
+     *    are at most k tiles) */
+    uint tau = 0, tau_need = 0;
+    bool compact = n_tiles <= QWEN4_IDX_PRE_MAX_TILES;
+    if (compact && n_tiles > args.top_k) {
+        qwen4_idx_radix<0>(tm, keys, tiles, row, n, n_tiles, args.top_k, nth, tid, sgitg, tiisg,
+                           hist, scan, found, tau, tau_need);
+    }
+    /* 2. survivors in ascending tile order: contiguous tile chunk per thread,
+     *    ranks by exclusive scan */
+    uint n_surv = 0;
+    const uint tchunk = (n_tiles + nth - 1) / nth;
+    const uint t0 = min((uint)tid * tchunk, n_tiles), t1 = min(t0 + tchunk, n_tiles);
+    if (compact) {
+        for (uint t = t0; t < t1; t++) n_surv += tm[t] >= tau;
+    }
+    uint rank = simd_prefix_exclusive_sum(n_surv);
+    if (tiisg == 31) scan[sgitg] = rank + n_surv;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (sgitg == 0) {
+        const uint nsg = (nth + 31) / 32;
+        const uint sv = tiisg < nsg ? scan[tiisg] : 0u;
+        const uint sp = simd_prefix_exclusive_sum(sv);
+        if (tiisg < nsg) scan[tiisg] = sp;
+        if (tiisg == nsg - 1) total_surv = sp + sv;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    rank += scan[sgitg];
+    compact = compact && total_surv <= QWEN4_IDX_PRE_TILES;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (compact) {
+        for (uint t = t0; t < t1; t++) {
+            if (tm[t] < tau) continue;
+            tiles[rank] = (ushort)t;
+            for (uint j = 0; j < 8; j++) {
+                const uint b = t * 8u + j;
+                keys[rank * 8u + j] = b < n ? as_type<uint>(max(row[b], 0.0f)) : 0u;
+            }
+            rank++;
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    const uint n_c = compact ? total_surv * 8u : n;
+
+    /* 3. k-th key and equal count over the compact set (or the full row) */
+    uint prefix, need;
+    if (compact) {
+        qwen4_idx_radix<1>(tm, keys, tiles, row, n, n_c, args.top_k, nth, tid, sgitg, tiisg,
+                           hist, scan, found, prefix, need);
+    } else {
+        qwen4_idx_radix<2>(tm, keys, tiles, row, n, n, args.top_k, nth, tid, sgitg, tiisg,
+                           hist, scan, found, prefix, need);
+    }
+    /* Missing blocks of the last tile carry key 0 and must not count as
+     * equals when the k-th key is 0; the block test excludes them below. */
+
+    /* 4. gather: contiguous entry chunk per thread, ranks by exclusive scan */
+    const uint chunk = (n_c + nth - 1) / nth;
+    const uint e0 = min((uint)tid * chunk, n_c), e1 = min(e0 + chunk, n_c);
+    uint n_gt = 0, n_eq = 0;
+    for (uint e = e0; e < e1; e++) {
+        const uint b = compact ? qwen4_idx_pre_block(tiles, e) : e;
+        if (b >= n) continue;
+        const uint key = compact ? keys[e] : as_type<uint>(max(row[e], 0.0f));
+        n_gt += key > prefix; n_eq += key == prefix;
+    }
+    uint r_gt, r_eq;
+    for (uint which = 0; which < 2; which++) {
+        const uint v = which == 0 ? n_gt : n_eq;
+        const uint p = simd_prefix_exclusive_sum(v);
+        if (tiisg == 31) scan[sgitg] = p + v;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (sgitg == 0) {
+            const uint nsg = (nth + 31) / 32;
+            const uint sv = tiisg < nsg ? scan[tiisg] : 0u;
+            const uint sp = simd_prefix_exclusive_sum(sv);
+            if (tiisg < nsg) scan[tiisg] = sp;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (which == 0) r_gt = p + scan[sgitg]; else r_eq = p + scan[sgitg];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    const uint eq_base = args.top_k - need;
+    for (uint e = e0; e < e1; e++) {
+        const uint b = compact ? qwen4_idx_pre_block(tiles, e) : e;
+        if (b >= n) continue;
+        const uint key = compact ? keys[e] : as_type<uint>(max(row[e], 0.0f));
+        if (key > prefix) out[r_gt++] = (int32_t)b;
+        else if (key == prefix) { if (r_eq < need) out[eq_base + r_eq] = (int32_t)b; r_eq++; }
     }
 }
 
@@ -1561,11 +1745,22 @@ kernel void kernel_qwen4_attn_merge_wide(
     for (uint s = 0; s < args.n_splits; s++) mm = max(mm, base[s * stride]);
     float ll = 0.0f;
     float o = 0.0f;
-    for (uint s = 0; s < args.n_splits; s++) {
-        device const float *p = base + s * stride;
-        const float c = p[1] > 0.0f ? exp(p[0] - mm) : 0.0f;
-        ll += p[1] * c;
-        o += p[2u + tid] * c;
+    /* sixteen splits' values in flight per round; the chain below still
+     * visits the splits in order */
+    for (uint s0 = 0; s0 < args.n_splits; s0 += 16u) {
+        float pm[16], pl[16], po[16];
+        const uint n_round = min(16u, args.n_splits - s0);
+        for (uint i = 0; i < 16u; i++) {
+            device const float *p = base + (s0 + min(i, n_round - 1u)) * stride;
+            pm[i] = p[0];
+            pl[i] = p[1];
+            po[i] = p[2u + tid];
+        }
+        for (uint i = 0; i < n_round; i++) {
+            const float c = pl[i] > 0.0f ? exp(pm[i] - mm) : 0.0f;
+            ll += pl[i] * c;
+            o += po[i] * c;
+        }
     }
     const float inv = ll > 0.0f ? 1.0f / ll : 0.0f;
     const uint64_t at = ((uint64_t)tok * H + h) * D + tid;

--- a/metal/qwen4.metal
+++ b/metal/qwen4.metal
@@ -1139,6 +1139,49 @@ kernel void kernel_qwen4_idx_score(
     score[(uint64_t)tok * args.n_blocks + b] = sum;
 }
 
+/* Same scores with the token's query rows staged once per threadgroup and
+ * the block key read as half4 vectors; every dot still adds its 128 terms
+ * in index order, so the sums are bit-identical to kernel_qwen4_idx_score. */
+kernel void kernel_qwen4_idx_score_vec(
+        constant ds4_metal_args_qwen4_idx_score & args,
+        device const float *iq,          /* [T][Hi*Di] */
+        device const half  *block_key,   /* [n_blocks][Di] */
+        device float       *score,       /* [T][n_blocks] */
+        uint3 tgpig [[threadgroup_position_in_grid]],
+        ushort tid [[thread_index_in_threadgroup]],
+        ushort3 ntg [[threads_per_threadgroup]]) {
+    threadgroup float qs[4 * 128];
+    const uint tok = tgpig.y;
+    const uint Di = args.idx_dim;
+    const uint nq = args.n_idx_head * Di;
+    if (tok >= args.n_tokens || nq > 4u * 128u || (Di & 3u) != 0u) return;
+    device const float *q = iq + (uint64_t)tok * nq;
+    for (uint i = tid; i < nq; i += ntg.x) qs[i] = q[i];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    const uint b = tgpig.x * ntg.x + tid;
+    if (b >= args.n_blocks) return;
+    const uint visible = (args.pos0 + tok + 1) / args.ratio;
+    if (b >= visible) {
+        score[(uint64_t)tok * args.n_blocks + b] = -3.0e38f;
+        return;
+    }
+    device const half4 *key = (device const half4 *)(block_key + (uint64_t)b * Di);
+    float sum = 0.0f;
+    for (uint h = 0; h < args.n_idx_head; h++) {
+        const threadgroup float *qh = qs + h * Di;
+        float dot = 0.0f;
+        for (uint d = 0; d < Di; d += 4) {
+            const half4 k = key[d >> 2];
+            dot += qh[d] * (float)k.x;
+            dot += qh[d + 1] * (float)k.y;
+            dot += qh[d + 2] * (float)k.z;
+            dot += qh[d + 3] * (float)k.w;
+        }
+        sum += max(dot, 0.0f);
+    }
+    score[(uint64_t)tok * args.n_blocks + b] = sum;
+}
+
 /* Matrix-unit block scorer for 4 heads x 128 dims: a threadgroup scores 16
  * tokens x 64 blocks.  Per K half the 64 keys and the 64 query rows (16
  * tokens x 4 heads, rounded to half, stored transposed) are staged so both
@@ -1493,6 +1536,48 @@ kernel void kernel_qwen4_attn_merge(
 #pragma unroll
     for (uint i = 0; i < NPT; i++) dst[i] = o[i] * inv * qwen4_sigmoid(gt[i]);
 }
+
+/* Same merge with one thread per dim: lane d runs the split chain the
+ * 32-lane kernel ran for dim d (m and l are recomputed identically per
+ * lane), so the outputs match bit for bit with eight times the threads. */
+template <uint NPT>
+kernel void kernel_qwen4_attn_merge_wide(
+        constant ds4_metal_args_qwen4_attn_decode & args,
+        device const float *part,
+        device const float *gate,
+        device float       *out,
+        uint3 tgpig [[threadgroup_position_in_grid]],
+        ushort tid [[thread_index_in_threadgroup]]) {
+    const uint h = tgpig.x;
+    const uint tok = tgpig.y;
+    constexpr uint D = NPT * 32;
+    if (h >= args.n_head || tok >= args.n_tokens || tid >= D) return;
+    const uint H = args.n_head, Hkv = args.n_head_kv;
+    const uint group = H / Hkv;
+    const uint kvh = h / group, g = h % group;
+    const uint64_t stride = (uint64_t)group * (2u + D);
+    device const float *base = part + (((uint64_t)tok * Hkv + kvh) * args.n_splits * group + g) * (2u + D);
+    float mm = -3.0e38f;
+    for (uint s = 0; s < args.n_splits; s++) mm = max(mm, base[s * stride]);
+    float ll = 0.0f;
+    float o = 0.0f;
+    for (uint s = 0; s < args.n_splits; s++) {
+        device const float *p = base + s * stride;
+        const float c = p[1] > 0.0f ? exp(p[0] - mm) : 0.0f;
+        ll += p[1] * c;
+        o += p[2u + tid] * c;
+    }
+    const float inv = ll > 0.0f ? 1.0f / ll : 0.0f;
+    const uint64_t at = ((uint64_t)tok * H + h) * D + tid;
+    out[at] = o * inv * qwen4_sigmoid(gate[at]);
+}
+
+#define QWEN4_ATTN_MERGE_WIDE_INSTANCE(NPT_) \
+template [[host_name("kernel_qwen4_attn_merge_wide_npt" #NPT_)]] \
+kernel void kernel_qwen4_attn_merge_wide<NPT_>(constant ds4_metal_args_qwen4_attn_decode &, device const float *, \
+        device const float *, device float *, uint3, ushort);
+QWEN4_ATTN_MERGE_WIDE_INSTANCE(8)
+QWEN4_ATTN_MERGE_WIDE_INSTANCE(4)
 
 #define QWEN4_ATTN_INSTANCE(NPT_) \
 template [[host_name("kernel_qwen4_attn_decode_npt" #NPT_)]] \

--- a/metal/qwen4.metal
+++ b/metal/qwen4.metal
@@ -2096,8 +2096,17 @@ struct ds4_metal_args_qwen4_moe_mm {
     uint32_t n_expert;
     uint32_t tiles_per_launch;
     uint32_t tail_base; /* host binds the same value to function constant 905 */
-    uint32_t pad1;
+    uint32_t expert_major; /* grid x = tile * row_blocks + row_block, z = 1 */
 };
+
+/* Threadgroup -> (row block, first tile).  Expert-major order keeps one
+ * expert's tiles adjacent so its rows are reused from cache; the K loop and
+ * accumulation order of every tile are unchanged. */
+static inline uint2 qwen4_moe_mm_block(constant ds4_metal_args_qwen4_moe_mm & args, uint3 tgpig) {
+    if (!args.expert_major) return uint2(tgpig.x, tgpig.z);
+    const uint n_rb = (args.out_rows + 31u) / 32u;   /* QWEN4_MM_ROWS-sized blocks */
+    return uint2(tgpig.x % n_rb, tgpig.x / n_rb);
+}
 
 /* Zero retains runtime dispatch; a bound quantization removes the other
  * dequantizers without changing the tile arithmetic. */
@@ -2264,7 +2273,8 @@ kernel void kernel_qwen4_moe_mm_mid(
         ushort tid [[thread_index_in_threadgroup]],
         ushort sgitg [[simdgroup_index_in_threadgroup]]) {
     constexpr uint TT = QWEN4_MM_TOKS * NT;
-    const uint rb = tgpig.x, e = tgpig.y;
+    const uint2 block = qwen4_moe_mm_block(args, tgpig);
+    const uint rb = block.x, e = tgpig.y;
     if (e >= args.n_expert) return;
     const uint count = (uint)counts[e];
     uint work_count = count, work_start = 0;
@@ -2288,7 +2298,7 @@ kernel void kernel_qwen4_moe_mm_mid(
     device const int32_t *list = lists + (uint64_t)e * args.list_cap;
     const uint row0 = rb * QWEN4_MM_ROWS;
     const uint nk = args.in_dim / QWEN4_MM_KS;
-    for (uint tile = tgpig.z; tile * TT < work_count; tile += args.tiles_per_launch) {
+    for (uint tile = block.y; tile * TT < work_count; tile += args.tiles_per_launch) {
         const uint t0 = work_start + tile * TT;
         const uint n_tile = min((uint)TT, work_count - tile * TT);
         simdgroup_float8x8 Cg[NT], Cu[NT];
@@ -2382,7 +2392,8 @@ kernel void kernel_qwen4_moe_mm_down(
         ushort tid [[thread_index_in_threadgroup]],
         ushort sgitg [[simdgroup_index_in_threadgroup]]) {
     constexpr uint TT = QWEN4_MM_TOKS * NT;
-    const uint rb = tgpig.x, e = tgpig.y;
+    const uint2 block = qwen4_moe_mm_block(args, tgpig);
+    const uint rb = block.x, e = tgpig.y;
     if (e >= args.n_expert) return;
     const uint count = (uint)counts[e];
     uint work_count = count, work_start = 0;
@@ -2404,7 +2415,7 @@ kernel void kernel_qwen4_moe_mm_down(
     device const int32_t *list = lists + (uint64_t)e * args.list_cap;
     const uint row0 = rb * QWEN4_MM_ROWS;
     const uint nk = args.in_dim / QWEN4_MM_KS;
-    for (uint tile = tgpig.z; tile * TT < work_count; tile += args.tiles_per_launch) {
+    for (uint tile = block.y; tile * TT < work_count; tile += args.tiles_per_launch) {
         const uint t0 = work_start + tile * TT;
         const uint n_tile = min((uint)TT, work_count - tile * TT);
         simdgroup_float8x8 C[NT];

--- a/speed-bench/.gitignore
+++ b/speed-bench/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 local-runs/
 metal_decode_schedule_bench
 metal_prefill_variant_bench
+qwen38_decode_variant_bench

--- a/speed-bench/metal_prefill_variant_bench.c
+++ b/speed-bench/metal_prefill_variant_bench.c
@@ -26,6 +26,10 @@ typedef struct {
     const char *candidate_env;
     const char *candidate_value;
     const char *control_value;
+    const char *extra_env[16];    /* candidate-only NAME=VALUE settings */
+    const char *control_env[16];  /* control-only NAME=VALUE settings */
+    int n_extra;
+    int n_control;
     int prefill_chunk;
     int prefix_tokens;
     int initial_tokens;
@@ -50,6 +54,8 @@ static void usage(FILE *fp, const char *argv0) {
             "  --candidate-env NAME   unset NAME for control, set it for candidate\n"
             "  --candidate-value TEXT candidate env value (default: 1)\n"
             "  --control-value TEXT   explicit control env value (default: unset)\n"
+            "  --extra-env NAME=VALUE additional candidate-only setting; repeatable\n"
+            "  --control-env NAME=VALUE control-only setting; repeatable\n"
             "  --prefill-chunk N      tokens per chunk (default: 4096)\n"
             "  --prefix-tokens N      final prefill length (default: 8192)\n"
             "  --initial-tokens N     untimed live prefix before appending to that length\n"
@@ -115,6 +121,15 @@ static bench_config parse_options(int argc, char **argv) {
             cfg.prefill_chunk = parse_int_arg(need_arg(&i, argc, argv, arg), arg, 1);
         } else if (!strcmp(arg, "--candidate-env")) {
             cfg.candidate_env = need_arg(&i, argc, argv, arg);
+        } else if (!strcmp(arg, "--extra-env") || !strcmp(arg, "--control-env")) {
+            const char *spec = need_arg(&i, argc, argv, arg);
+            const char **list = arg[2] == 'e' ? cfg.extra_env : cfg.control_env;
+            int *n = arg[2] == 'e' ? &cfg.n_extra : &cfg.n_control;
+            if (!strchr(spec, '=') || spec[0] == '=' || *n >= 16) {
+                fprintf(stderr, "%s: %s needs NAME=VALUE (at most 16)\n", BENCH_NAME, arg);
+                exit(2);
+            }
+            list[(*n)++] = spec;
         } else if (!strcmp(arg, "--prefix-tokens")) {
             cfg.prefix_tokens =
                 parse_int_arg(need_arg(&i, argc, argv, arg), arg, 1);
@@ -208,9 +223,26 @@ static char *read_text(const char *path) {
     return text;
 }
 
+static int apply_env_list(const char *const *list, int n, bool set) {
+    for (int i = 0; i < n; i++) {
+        const char *eq = strchr(list[i], '=');
+        char name[128];
+        const size_t len = (size_t)(eq - list[i]);
+        if (len >= sizeof(name)) return 1;
+        memcpy(name, list[i], len);
+        name[len] = '\0';
+        if ((set ? setenv(name, eq + 1, 1) : unsetenv(name)) != 0) return 1;
+    }
+    return 0;
+}
+
 static int select_variant(const bench_config *cfg, int variant) {
-    const int env_rc =
-        variant == 0
+    /* Control: candidate settings unset (or set to --control-value),
+     * control-only settings applied.  Candidate: control-only settings
+     * unset, candidate settings applied. */
+    int env_rc = apply_env_list(cfg->control_env, cfg->n_control, variant == 0);
+    env_rc |= apply_env_list(cfg->extra_env, cfg->n_extra, variant != 0);
+    env_rc |= variant == 0
             ? (cfg->control_value ? setenv(cfg->candidate_env, cfg->control_value, 1) : unsetenv(cfg->candidate_env))
             : setenv(cfg->candidate_env, cfg->candidate_value, 1);
     if (env_rc != 0) {

--- a/speed-bench/metal_prefill_variant_bench.c
+++ b/speed-bench/metal_prefill_variant_bench.c
@@ -30,6 +30,7 @@ typedef struct {
     const char *control_env[16];  /* control-only NAME=VALUE settings */
     int n_extra;
     int n_control;
+    bool interleave;
     int prefill_chunk;
     int prefix_tokens;
     int initial_tokens;
@@ -61,7 +62,10 @@ static void usage(FILE *fp, const char *argv0) {
             "  --initial-tokens N     untimed live prefix before appending to that length\n"
             "  --warmup-tokens N      untimed tokens per variant (default: 32; min: 32)\n"
             "  --ctx N                session allocation (default: max lengths + 1)\n"
-            "  --repeats N            alternating ABBA/BAAB pairs (default: 2)\n",
+            "  --repeats N            alternating ABBA/BAAB pairs (default: 2)\n"
+            "  --interleave           one session per repeat, prefilled chunk by chunk with the\n"
+            "                         variant alternating per chunk (and per repeat), so both\n"
+            "                         variants share the machine state and every position\n",
             argv0);
 }
 
@@ -130,6 +134,8 @@ static bench_config parse_options(int argc, char **argv) {
                 exit(2);
             }
             list[(*n)++] = spec;
+        } else if (!strcmp(arg, "--interleave")) {
+            cfg.interleave = true;
         } else if (!strcmp(arg, "--prefix-tokens")) {
             cfg.prefix_tokens =
                 parse_int_arg(need_arg(&i, argc, argv, arg), arg, 1);
@@ -422,6 +428,77 @@ int main(int argc, char **argv) {
     ds4_tokens initial = { .v = tokens.v, .len = cfg.initial_tokens, .cap = cfg.initial_tokens };
     const int timed_tokens = cfg.prefix_tokens - cfg.initial_tokens;
     size_t run = 0;
+    if (cfg.interleave) {
+        /* Sustained load drifts the GPU by several percent within a minute,
+         * and single fresh-session runs carry positional outliers, so
+         * measure both variants inside the same session: every chunk after
+         * --initial-tokens is timed under the variant of its parity, and the
+         * next repeat swaps the parity.  Final logits must match across
+         * repeats, which pins every chunk of both variants. */
+        const int chunk = cfg.prefill_chunk;
+        if (timed_tokens % chunk != 0 || cfg.initial_tokens % chunk != 0) {
+            fprintf(stderr, "%s: --interleave needs --initial-tokens and --prefix-tokens as multiples of --prefill-chunk\n", BENCH_NAME);
+            goto done;
+        }
+        /* The first session that reaches a context length pays first-use
+         * costs on its buffers for every chunk after the first (measured at
+         * -25% on an M5 Max), so pass 0 walks the whole prefix untimed. */
+        for (int repeat = -1; repeat < cfg.repeats; repeat++) {
+            const bool timed = repeat >= 0;
+            ds4_session *session = NULL;
+            if (select_variant(&cfg, 0) != 0 || ds4_session_create(&session, engine, cfg.ctx) != 0) {
+                fprintf(stderr, "%s: failed to create interleaved session %d\n", BENCH_NAME, repeat + 1);
+                goto done;
+            }
+            err[0] = '\0';
+            if (initial.len && ds4_session_sync(session, &initial, err, sizeof(err)) != 0) {
+                fprintf(stderr, "%s: initial prefix failed: %s\n", BENCH_NAME, err);
+                ds4_session_free(session);
+                goto done;
+            }
+            for (int c = 0; c < timed_tokens / chunk; c++) {
+                const int variant = (c + repeat) & 1;
+                ds4_tokens part = { .v = tokens.v, .len = cfg.initial_tokens + (c + 1) * chunk,
+                                    .cap = cfg.initial_tokens + (c + 1) * chunk };
+                if (select_variant(&cfg, variant) != 0) { ds4_session_free(session); goto done; }
+                const double t0 = now_sec();
+                const int sync_rc = ds4_session_sync(session, &part, err, sizeof(err));
+                const double seconds = now_sec() - t0;
+                if (sync_rc != 0 || ds4_session_pos(session) != part.len) {
+                    fprintf(stderr, "%s: interleaved chunk %d failed: %s\n", BENCH_NAME, c + 1, err[0] ? err : "position");
+                    ds4_session_free(session);
+                    goto done;
+                }
+                if (timed) {
+                    results[variant].seconds += seconds;
+                    results[variant].runs++;
+                    results[variant].tokens += (size_t)chunk;
+                }
+                printf("run=%zu repeat=%d pattern=%s slot=%d variant=%s tokens=%d seconds=%.6f tokens_per_second=%.4f exact=%s\n",
+                       run + 1, repeat + 1, !timed ? "warm" : repeat & 1 ? "BABA" : "ABAB", c + 1,
+                       variant == 0 ? "control" : "candidate", chunk, seconds,
+                       seconds > 0.0 ? (double)chunk / seconds : 0.0, timed ? "pending" : "untimed");
+                fflush(stdout);
+                if (timed) run++;
+            }
+            memset(observed, (repeat & 1) == 0 ? 0xa5 : 0x5a, logit_bytes);
+            if (ds4_session_copy_logits(session, observed, vocab) != vocab) {
+                fprintf(stderr, "%s: failed to copy logits after repeat %d\n", BENCH_NAME, repeat + 1);
+                ds4_session_free(session);
+                goto done;
+            }
+            if (!have_reference) {
+                memcpy(reference, observed, logit_bytes);
+                have_reference = true;
+            } else if (compare_logits(reference, observed, vocab, (size_t)repeat + 1) != 0) {
+                ds4_session_free(session);
+                goto done;
+            }
+            if (timed) exact_runs++;
+            printf("repeat=%d final logits exact=yes\n", repeat + 1);
+            ds4_session_free(session);
+        }
+    } else
     for (int repeat = 0; repeat < cfg.repeats; repeat++) {
         const int *order = orders[repeat & 1];
         const char *pattern = (repeat & 1) == 0 ? "ABBA" : "BAAB";

--- a/speed-bench/qwen38-m5-round1-results.json
+++ b/speed-bench/qwen38-m5-round1-results.json
@@ -1,0 +1,2057 @@
+{
+ "hardware": "Apple M5 Max, 128 GiB unified memory, 40-core GPU, Metal 4",
+ "model": "Qwen3.8-Flash-Next-Q4KImatrixExperts-MXFP4Down-BF16Emb-BF16Control-Q8GDN-Q8QSA-Q8Shared-Q8Out-MTP.gguf",
+ "ple": "Qwen3.8-Flash-Next-PLE-Q4_1.gguf",
+ "baseline_commit": "82d0314",
+ "decode_ab": {
+  "harness": "speed-bench/qwen38_decode_variant_bench",
+  "prefix_tokens": 2048,
+  "warmup": 16,
+  "measured": 384,
+  "protocol": "one engine, two sessions, per-step alternating variant order and session pairing, every logit row compared",
+  "phase1": [
+   {
+    "time": "20:06:32",
+    "kind": "decode",
+    "label": "q4k-nr1-nsg8",
+    "env": "DS4_QWEN4_Q4K_MID_NR=1,DS4_QWEN4_Q4K_MID_NSG=8",
+    "extra_args": "",
+    "result": {
+     "speedup": 1.0162,
+     "percent": 1.621,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:07:06",
+    "kind": "decode",
+    "label": "q4k-nr1-nsg4",
+    "env": "DS4_QWEN4_Q4K_MID_NR=1,DS4_QWEN4_Q4K_MID_NSG=4",
+    "extra_args": "",
+    "result": {
+     "speedup": 1.0194,
+     "percent": 1.94,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:07:40",
+    "kind": "decode",
+    "label": "q4k-nr1-nsg2",
+    "env": "DS4_QWEN4_Q4K_MID_NR=1,DS4_QWEN4_Q4K_MID_NSG=2",
+    "extra_args": "",
+    "result": {
+     "speedup": 1.0136,
+     "percent": 1.363,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:08:14",
+    "kind": "decode",
+    "label": "q4k-nr2-nsg4",
+    "env": "DS4_QWEN4_Q4K_MID_NR=2,DS4_QWEN4_Q4K_MID_NSG=4",
+    "extra_args": "",
+    "result": {
+     "speedup": 0.996,
+     "percent": -0.398,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:08:48",
+    "kind": "decode",
+    "label": "q4k-nr2-nsg8",
+    "env": "DS4_QWEN4_Q4K_MID_NR=2,DS4_QWEN4_Q4K_MID_NSG=8",
+    "extra_args": "",
+    "result": {
+     "speedup": 0.9979,
+     "percent": -0.207,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:09:23",
+    "kind": "decode",
+    "label": "decode-fusions",
+    "env": "DS4_QWEN4_DECODE_FUSIONS=1",
+    "extra_args": "",
+    "result": {
+     "speedup": 0.9919,
+     "percent": -0.812,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:09:58",
+    "kind": "decode",
+    "label": "mv-spec",
+    "env": "DS4_QWEN4_MOE_MV_SPECIALIZE=1",
+    "extra_args": "",
+    "result": {
+     "speedup": 1.013,
+     "percent": 1.295,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:10:32",
+    "kind": "decode",
+    "label": "mv-spec-nsg4",
+    "env": "DS4_QWEN4_MOE_MV_SPECIALIZE=1,DS4_QWEN4_MOE_MV_NSG=4",
+    "extra_args": "",
+    "result": {
+     "speedup": 1.0112,
+     "percent": 1.117,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:11:06",
+    "kind": "decode",
+    "label": "mv-spec-nsg16",
+    "env": "DS4_QWEN4_MOE_MV_SPECIALIZE=1,DS4_QWEN4_MOE_MV_NSG=16",
+    "extra_args": "",
+    "result": {
+     "speedup": 1.0192,
+     "percent": 1.918,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:11:40",
+    "kind": "decode",
+    "label": "mv-spec-nr2",
+    "env": "DS4_QWEN4_MOE_MV_SPECIALIZE=1,DS4_QWEN4_MOE_MV_NR=2",
+    "extra_args": "",
+    "result": {
+     "speedup": 1.0167,
+     "percent": 1.67,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:12:15",
+    "kind": "decode",
+    "label": "gdn-nsg2",
+    "env": "DS4_QWEN4_GDN_NSG=2",
+    "extra_args": "",
+    "result": {
+     "speedup": 0.9987,
+     "percent": -0.13,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:12:49",
+    "kind": "decode",
+    "label": "gdn-nsg4",
+    "env": "DS4_QWEN4_GDN_NSG=4",
+    "extra_args": "",
+    "result": {
+     "speedup": 1.001,
+     "percent": 0.099,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:13:23",
+    "kind": "decode",
+    "label": "gdn-nsg8",
+    "env": "DS4_QWEN4_GDN_NSG=8",
+    "extra_args": "",
+    "result": {
+     "speedup": 0.9952,
+     "percent": -0.482,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:13:58",
+    "kind": "decode",
+    "label": "no-gdn-r4",
+    "env": "DS4_QWEN4_NO_GDN_R4=1",
+    "extra_args": "",
+    "result": {
+     "speedup": 0.9881,
+     "percent": -1.191,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:14:32",
+    "kind": "decode",
+    "label": "no-q4k-mid",
+    "env": "DS4_QWEN4_NO_Q4K_MID=1",
+    "extra_args": "",
+    "result": {
+     "speedup": 0.9606,
+     "percent": -3.942,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   }
+  ],
+  "phase1b": [
+   {
+    "time": "20:15:54",
+    "kind": "decode",
+    "label": "q8mv-nsg2",
+    "env": "DS4_METAL_Q8_MV_NSG=2",
+    "extra_args": "",
+    "result": {
+     "error": "qwen38-decode-variant-bench: raw logit mismatch at step 1: differing=246925/248320 top0=21605 top1=21605 first id=0 control=0x1.686114p+0 (0x3fb4308a) candidate=0x1.6861d8p+0 (0x3fb430ec)"
+    },
+    "exact": false
+   },
+   {
+    "time": "20:16:12",
+    "kind": "decode",
+    "label": "q8mv-nsg8",
+    "env": "DS4_METAL_Q8_MV_NSG=8",
+    "extra_args": "",
+    "result": {
+     "error": "qwen38-decode-variant-bench: raw logit mismatch at step 1: differing=246559/248320 top0=21605 top1=21605 first id=0 control=0x1.686114p+0 (0x3fb4308a) candidate=0x1.686064p+0 (0x3fb43032)"
+    },
+    "exact": false
+   },
+   {
+    "time": "20:16:30",
+    "kind": "decode",
+    "label": "q8mv-nsg1",
+    "env": "DS4_METAL_Q8_MV_NSG=1",
+    "extra_args": "",
+    "result": {
+     "error": "qwen38-decode-variant-bench: raw logit mismatch at step 1: differing=246887/248320 top0=21605 top1=21605 first id=0 control=0x1.686114p+0 (0x3fb4308a) candidate=0x1.68617p+0 (0x3fb430b8)"
+    },
+    "exact": false
+   },
+   {
+    "time": "20:16:47",
+    "kind": "decode",
+    "label": "flush1",
+    "env": "DS4_QWEN4_FLUSH_LAYER=1",
+    "extra_args": "",
+    "result": {
+     "speedup": 0.9942,
+     "percent": -0.58,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:17:21",
+    "kind": "decode",
+    "label": "flush4",
+    "env": "DS4_QWEN4_FLUSH_LAYER=4",
+    "extra_args": "",
+    "result": {
+     "speedup": 0.9958,
+     "percent": -0.415,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:17:56",
+    "kind": "decode",
+    "label": "flush8",
+    "env": "DS4_QWEN4_FLUSH_LAYER=8",
+    "extra_args": "",
+    "result": {
+     "speedup": 0.9948,
+     "percent": -0.525,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:18:30",
+    "kind": "decode",
+    "label": "flush0",
+    "env": "DS4_QWEN4_FLUSH_LAYER=0",
+    "extra_args": "",
+    "result": {
+     "speedup": 0.9762,
+     "percent": -2.378,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:19:05",
+    "kind": "decode",
+    "label": "combo-a",
+    "env": "DS4_QWEN4_Q4K_MID_NR=1,DS4_QWEN4_Q4K_MID_NSG=4,DS4_QWEN4_MOE_MV_SPECIALIZE=1,DS4_QWEN4_MOE_MV_NSG=16",
+    "extra_args": "",
+    "result": {
+     "speedup": 1.038,
+     "percent": 3.796,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:19:39",
+    "kind": "decode",
+    "label": "combo-b",
+    "env": "DS4_QWEN4_Q4K_MID_NR=1,DS4_QWEN4_Q4K_MID_NSG=8,DS4_QWEN4_MOE_MV_SPECIALIZE=1,DS4_QWEN4_MOE_MV_NSG=16",
+    "extra_args": "",
+    "result": {
+     "speedup": 1.0365,
+     "percent": 3.646,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:20:13",
+    "kind": "decode",
+    "label": "mv-spec-nsg16-nr2",
+    "env": "DS4_QWEN4_MOE_MV_SPECIALIZE=1,DS4_QWEN4_MOE_MV_NSG=16,DS4_QWEN4_MOE_MV_NR=2",
+    "extra_args": "",
+    "result": {
+     "speedup": 1.0142,
+     "percent": 1.425,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:20:47",
+    "kind": "decode",
+    "label": "mv-spec-nsg12",
+    "env": "DS4_QWEN4_MOE_MV_SPECIALIZE=1,DS4_QWEN4_MOE_MV_NSG=12",
+    "extra_args": "",
+    "result": {
+     "speedup": 1.0104,
+     "percent": 1.044,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:21:21",
+    "kind": "decode",
+    "label": "q4k-nr1-nsg6",
+    "env": "DS4_QWEN4_Q4K_MID_NR=1,DS4_QWEN4_Q4K_MID_NSG=6",
+    "extra_args": "",
+    "result": {
+     "speedup": 1.0208,
+     "percent": 2.084,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:21:55",
+    "kind": "decode",
+    "label": "mpp-probe",
+    "env": "DS4_METAL_Q8_DECODE_MPP_PROBE=1",
+    "extra_args": "",
+    "result": {
+     "error": "qwen38-decode-variant-bench: raw logit mismatch at step 1: differing=248307/248320 top0=21605 top1=21605 first id=0 control=0x1.686114p+0 (0x3fb4308a) candidate=0x1.68d6fap+0 (0x3fb46b7d)"
+    },
+    "exact": false
+   }
+  ],
+  "after_m5_defaults": [
+   {
+    "time": "20:55:43",
+    "kind": "decode",
+    "label": "noop2",
+    "env": "DS4_NOOP_PROBE=1",
+    "extra_args": "",
+    "result": {
+     "speedup": 0.9971,
+     "percent": -0.294,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:56:21",
+    "kind": "decode",
+    "label": "q8-nr0-4",
+    "env": "DS4_METAL_Q8_MV_NR0=4",
+    "extra_args": "",
+    "result": {
+     "speedup": 0.9945,
+     "percent": -0.547,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:56:49",
+    "kind": "decode",
+    "label": "q8-pair",
+    "env": "DS4_QWEN4_Q8_PAIR=1",
+    "extra_args": "",
+    "result": {
+     "speedup": 0.9969,
+     "percent": -0.311,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:57:16",
+    "kind": "decode",
+    "label": "combine-norm",
+    "env": "DS4_QWEN4_COMBINE_NORM=1",
+    "extra_args": "",
+    "result": {
+     "speedup": 0.9971,
+     "percent": -0.293,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   },
+   {
+    "time": "20:57:43",
+    "kind": "decode",
+    "label": "hc-pair-nsg16",
+    "env": "DS4_QWEN4_HC_PAIR_NSG=16",
+    "extra_args": "",
+    "result": {
+     "speedup": 0.9991,
+     "percent": -0.094,
+     "exact_rows": 401,
+     "exact_floats": 99576320
+    },
+    "exact": true
+   }
+  ],
+  "long_context": []
+ },
+ "prefill_ab": {
+  "harness": "speed-bench/metal_prefill_variant_bench",
+  "prefill_chunk": 8192,
+  "prefix_tokens": 8192,
+  "warmup_tokens": 2048,
+  "repeats": 2,
+  "protocol": "one engine, fresh sessions, ABBA then BAAB, all 1,986,560 final logits compared per run",
+  "single_knob": [
+   {
+    "time": "20:22:14",
+    "kind": "prefill",
+    "label": "mm-spec",
+    "env": "DS4_QWEN4_MOE_MM_SPECIALIZE=1",
+    "extra_args": "",
+    "result": {
+     "percent": 16.4298,
+     "exact_runs": 8,
+     "exact_floats": 1986560
+    },
+    "exact": true
+   },
+   {
+    "time": "20:23:46",
+    "kind": "prefill",
+    "label": "gdn-pnsg4",
+    "env": "DS4_QWEN4_GDN_PREFILL_NSG=4",
+    "extra_args": "",
+    "result": {
+     "percent": 1.7104,
+     "exact_runs": 8,
+     "exact_floats": 1986560
+    },
+    "exact": true
+   },
+   {
+    "time": "20:25:16",
+    "kind": "prefill",
+    "label": "gdn-pnsg2",
+    "env": "DS4_QWEN4_GDN_PREFILL_NSG=2",
+    "extra_args": "",
+    "result": {
+     "percent": 0.1836,
+     "exact_runs": 8,
+     "exact_floats": 1986560
+    },
+    "exact": true
+   },
+   {
+    "time": "20:26:47",
+    "kind": "prefill",
+    "label": "gdn-pnsg8",
+    "env": "DS4_QWEN4_GDN_PREFILL_NSG=8",
+    "extra_args": "",
+    "result": {
+     "percent": 1.5951,
+     "exact_runs": 8,
+     "exact_floats": 1986560
+    },
+    "exact": true
+   },
+   {
+    "time": "20:28:26",
+    "kind": "prefill",
+    "label": "mid-tiles16",
+    "env": "DS4_QWEN4_MOE_MID_TILES=16",
+    "extra_args": "",
+    "result": {
+     "percent": 2.2174,
+     "exact_runs": 8,
+     "exact_floats": 1986560
+    },
+    "exact": true
+   },
+   {
+    "time": "20:30:00",
+    "kind": "prefill",
+    "label": "mid-tiles32",
+    "env": "DS4_QWEN4_MOE_MID_TILES=32",
+    "extra_args": "",
+    "result": {
+     "percent": 1.7366,
+     "exact_runs": 8,
+     "exact_floats": 1986560
+    },
+    "exact": true
+   },
+   {
+    "time": "20:31:34",
+    "kind": "prefill",
+    "label": "down-tiles16",
+    "env": "DS4_QWEN4_MOE_DOWN_TILES=16",
+    "extra_args": "",
+    "result": {
+     "percent": 1.1181,
+     "exact_runs": 8,
+     "exact_floats": 1986560
+    },
+    "exact": true
+   },
+   {
+    "time": "20:33:08",
+    "kind": "prefill",
+    "label": "down-tiles32",
+    "env": "DS4_QWEN4_MOE_DOWN_TILES=32",
+    "extra_args": "",
+    "result": {
+     "percent": 1.2375,
+     "exact_runs": 8,
+     "exact_floats": 1986560
+    },
+    "exact": true
+   },
+   {
+    "time": "20:34:43",
+    "kind": "prefill",
+    "label": "hc-norm-reuse",
+    "env": "DS4_QWEN4_HC_NORM_REUSE=1",
+    "extra_args": "",
+    "result": {
+     "percent": 2.8405,
+     "exact_runs": 8,
+     "exact_floats": 1986560
+    },
+    "exact": true
+   },
+   {
+    "time": "20:36:18",
+    "kind": "prefill",
+    "label": "mid-nt2",
+    "env": "DS4_QWEN4_MOE_MID_NT=2",
+    "extra_args": "",
+    "result": {
+     "percent": -3.0152,
+     "exact_runs": 8,
+     "exact_floats": 1986560
+    },
+    "exact": true
+   },
+   {
+    "time": "20:37:56",
+    "kind": "prefill",
+    "label": "down-nt2",
+    "env": "DS4_QWEN4_MOE_DOWN_NT=2",
+    "extra_args": "",
+    "result": {
+     "percent": -1.5224,
+     "exact_runs": 8,
+     "exact_floats": 1986560
+    },
+    "exact": true
+   },
+   {
+    "time": "20:39:33",
+    "kind": "prefill",
+    "label": "tails",
+    "env": "DS4_QWEN4_MOE_TAILS=1",
+    "extra_args": "",
+    "result": {
+     "percent": 2.5837,
+     "exact_runs": 8,
+     "exact_floats": 1986560
+    },
+    "exact": true
+   }
+  ],
+  "on_top_of_specialization": [
+   {
+    "time": "20:43:22",
+    "kind": "prefill",
+    "label": "noop",
+    "env": "DS4_NOOP_PROBE=1",
+    "extra_args": "",
+    "result": {
+     "percent": 1.6217,
+     "exact_runs": 8,
+     "exact_floats": 1986560
+    },
+    "exact": true
+   },
+   {
+    "time": "20:44:40",
+    "kind": "prefill",
+    "label": "spec+mid16",
+    "env": "DS4_QWEN4_MOE_MID_TILES=16",
+    "extra_args": "--control-env DS4_QWEN4_MOE_MM_SPECIALIZE=1 --extra-env DS4_QWEN4_MOE_MM_SPECIALIZE=1",
+    "result": {
+     "percent": 3.7242,
+     "exact_runs": 8,
+     "exact_floats": 1986560
+    },
+    "exact": true
+   },
+   {
+    "time": "20:46:10",
+    "kind": "prefill",
+    "label": "spec+mid32",
+    "env": "DS4_QWEN4_MOE_MID_TILES=32",
+    "extra_args": "--control-env DS4_QWEN4_MOE_MM_SPECIALIZE=1 --extra-env DS4_QWEN4_MOE_MM_SPECIALIZE=1",
+    "result": {
+     "percent": 4.5834,
+     "exact_runs": 8,
+     "exact_floats": 1986560
+    },
+    "exact": true
+   },
+   {
+    "time": "20:47:40",
+    "kind": "prefill",
+    "label": "spec+down32",
+    "env": "DS4_QWEN4_MOE_DOWN_TILES=32",
+    "extra_args": "--control-env DS4_QWEN4_MOE_MM_SPECIALIZE=1 --extra-env DS4_QWEN4_MOE_MM_SPECIALIZE=1",
+    "result": {
+     "percent": 2.8479,
+     "exact_runs": 8,
+     "exact_floats": 1986560
+    },
+    "exact": true
+   },
+   {
+    "time": "20:49:18",
+    "kind": "prefill",
+    "label": "spec+hcreuse",
+    "env": "DS4_QWEN4_HC_NORM_REUSE=1",
+    "extra_args": "--control-env DS4_QWEN4_MOE_MM_SPECIALIZE=1 --extra-env DS4_QWEN4_MOE_MM_SPECIALIZE=1",
+    "result": {
+     "percent": 4.1127,
+     "exact_runs": 8,
+     "exact_floats": 1986560
+    },
+    "exact": true
+   },
+   {
+    "time": "20:50:52",
+    "kind": "prefill",
+    "label": "spec+tails",
+    "env": "DS4_QWEN4_MOE_TAILS=1",
+    "extra_args": "--control-env DS4_QWEN4_MOE_MM_SPECIALIZE=1 --extra-env DS4_QWEN4_MOE_MM_SPECIALIZE=1",
+    "result": {
+     "percent": 5.1389,
+     "exact_runs": 8,
+     "exact_floats": 1986560
+    },
+    "exact": true
+   },
+   {
+    "time": "20:52:26",
+    "kind": "prefill",
+    "label": "spec+gdn4",
+    "env": "DS4_QWEN4_GDN_PREFILL_NSG=4",
+    "extra_args": "--control-env DS4_QWEN4_MOE_MM_SPECIALIZE=1 --extra-env DS4_QWEN4_MOE_MM_SPECIALIZE=1",
+    "result": {
+     "percent": 1.4297,
+     "exact_runs": 8,
+     "exact_floats": 1986560
+    },
+    "exact": true
+   },
+   {
+    "time": "20:54:03",
+    "kind": "prefill",
+    "label": "spec+all",
+    "env": "DS4_QWEN4_MOE_MID_TILES=16",
+    "extra_args": "--control-env DS4_QWEN4_MOE_MM_SPECIALIZE=1 --extra-env DS4_QWEN4_MOE_MM_SPECIALIZE=1 --extra-env DS4_QWEN4_MOE_DOWN_TILES=32 --extra-env DS4_QWEN4_HC_NORM_REUSE=1 --extra-env DS4_QWEN4_MOE_TAILS=1 --extra-env DS4_QWEN4_GDN_PREFILL_NSG=4",
+    "result": {
+     "percent": 6.7707,
+     "exact_runs": 8,
+     "exact_floats": 1986560
+    },
+    "exact": true
+   }
+  ],
+  "long_context_rollback": [
+   {
+    "time": "21:16:21",
+    "kind": "prefill",
+    "label": "spec-rollback-32k",
+    "env": "DS4_QWEN4_MOE_MM_SPECIALIZE=0",
+    "extra_args": "--initial-tokens 24576 --prefix-tokens 32768 --warmup-tokens 2048 --repeats 1",
+    "result": {
+     "percent": 11.2396,
+     "exact_runs": 4,
+     "exact_floats": 993280
+    },
+    "exact": true
+   },
+   {
+    "time": "21:18:44",
+    "kind": "prefill",
+    "label": "spec-rollback-128k",
+    "env": "DS4_QWEN4_MOE_MM_SPECIALIZE=0",
+    "extra_args": "--initial-tokens 122880 --prefix-tokens 131072 --warmup-tokens 2048 --repeats 1",
+    "result": null,
+    "exact": null
+   }
+  ],
+  "full_warmup_16_runs": [
+   {
+    "time": "21:30:31",
+    "kind": "prefill",
+    "label": "noop4",
+    "env": "DS4_NOOP_PROBE=1",
+    "extra_args": "--warmup-tokens 8192 --repeats 4",
+    "result": {
+     "percent": 1.3099,
+     "exact_runs": 16,
+     "exact_floats": 3973120
+    },
+    "exact": true
+   },
+   {
+    "time": "21:33:46",
+    "kind": "prefill",
+    "label": "spec-rollback",
+    "env": "DS4_QWEN4_MOE_MM_SPECIALIZE=0",
+    "extra_args": "--warmup-tokens 8192 --repeats 4",
+    "result": {
+     "percent": -0.9684,
+     "exact_runs": 16,
+     "exact_floats": 3973120
+    },
+    "exact": true
+   },
+   {
+    "time": "21:36:50",
+    "kind": "prefill",
+    "label": "tails",
+    "env": "DS4_QWEN4_MOE_TAILS=1",
+    "extra_args": "--warmup-tokens 8192 --repeats 4",
+    "result": {
+     "percent": 2.3422,
+     "exact_runs": 16,
+     "exact_floats": 3973120
+    },
+    "exact": true
+   },
+   {
+    "time": "21:39:58",
+    "kind": "prefill",
+    "label": "tails+mid32",
+    "env": "DS4_QWEN4_MOE_TAILS=1",
+    "extra_args": "--extra-env DS4_QWEN4_MOE_MID_TILES=32 --warmup-tokens 8192 --repeats 4",
+    "result": {
+     "percent": 4.4417,
+     "exact_runs": 16,
+     "exact_floats": 3973120
+    },
+    "exact": true
+   },
+   {
+    "time": "21:43:09",
+    "kind": "prefill",
+    "label": "tails+mid32+hcreuse",
+    "env": "DS4_QWEN4_MOE_TAILS=1",
+    "extra_args": "--extra-env DS4_QWEN4_MOE_MID_TILES=32 --extra-env DS4_QWEN4_HC_NORM_REUSE=1 --warmup-tokens 8192 --repeats 4",
+    "result": {
+     "percent": 7.4808,
+     "exact_runs": 16,
+     "exact_floats": 3973120
+    },
+    "exact": true
+   },
+   {
+    "time": "21:46:20",
+    "kind": "prefill",
+    "label": "all",
+    "env": "DS4_QWEN4_MOE_TAILS=1",
+    "extra_args": "--extra-env DS4_QWEN4_MOE_MID_TILES=32 --extra-env DS4_QWEN4_MOE_DOWN_TILES=32 --extra-env DS4_QWEN4_HC_NORM_REUSE=1 --extra-env DS4_QWEN4_GDN_PREFILL_NSG=4 --warmup-tokens 8192 --repeats 4",
+    "result": {
+     "percent": 7.4266,
+     "exact_runs": 16,
+     "exact_floats": 3973120
+    },
+    "exact": true
+   }
+  ],
+  "m5_defaults_rollback": [
+   {
+    "time": "22:04:47",
+    "kind": "prefill",
+    "label": "prefill-rollback-8k",
+    "env": "DS4_QWEN4_MOE_TAILS=0",
+    "extra_args": "--extra-env DS4_QWEN4_MOE_MID_TILES=8 --extra-env DS4_QWEN4_HC_NORM_REUSE=0 --warmup-tokens 8192 --repeats 4",
+    "result": {
+     "percent": -5.1108,
+     "exact_runs": 16,
+     "exact_floats": 3973120
+    },
+    "exact": true
+   },
+   {
+    "time": "22:07:20",
+    "kind": "prefill",
+    "label": "tiles16-rollback-4k",
+    "env": "DS4_QWEN4_MOE_MID_TILES=8",
+    "extra_args": "--prefill-chunk 4096 --prefix-tokens 4096 --warmup-tokens 4096 --repeats 4",
+    "result": {
+     "percent": -0.698,
+     "exact_runs": 16,
+     "exact_floats": 3973120
+    },
+    "exact": true
+   },
+   {
+    "time": "22:08:58",
+    "kind": "prefill",
+    "label": "tails-rollback-4k",
+    "env": "DS4_QWEN4_MOE_TAILS=0",
+    "extra_args": "--prefill-chunk 4096 --prefix-tokens 4096 --warmup-tokens 4096 --repeats 4",
+    "result": {
+     "percent": -4.1056,
+     "exact_runs": 16,
+     "exact_floats": 3973120
+    },
+    "exact": true
+   }
+  ],
+  "note": "runs before p6 used --warmup-tokens 2048 and are biased by a slow first timed run; p6/p7 use --warmup-tokens 8192 --repeats 4"
+ },
+ "dispatch_probe": "device Apple M5 Max\n--- independent kernel, 800 dispatches per command buffer, serial encoder ---\ntgs=    1 threads=    128: gpu 1.154 ms (1.44 us/dispatch), encode 0.140 ms (0.17 us/dispatch), wall 1.456 ms\ntgs=    8 threads=   1024: gpu 0.958 ms (1.20 us/dispatch), encode 0.100 ms (0.13 us/dispatch), wall 1.246 ms\ntgs=   40 threads=   5120: gpu 0.809 ms (1.01 us/dispatch), encode 0.140 ms (0.18 us/dispatch), wall 1.111 ms\ntgs=  320 threads=  40960: gpu 0.875 ms (1.09 us/dispatch), encode 0.107 ms (0.13 us/dispatch), wall 1.164 ms\ntgs= 1536 threads= 196608: gpu 1.526 ms (1.91 us/dispatch), encode 0.110 ms (0.14 us/dispatch), wall 1.813 ms\ntgs= 4096 threads= 524288: gpu 2.893 ms (3.62 us/dispatch), encode 0.145 ms (0.18 us/dispatch), wall 3.203 ms\n--- dependent kernel, 800 dispatches per command buffer, serial encoder ---\ntgs=    1 threads=    128: gpu 0.738 ms (0.92 us/dispatch), encode 0.123 ms (0.15 us/dispatch), wall 1.050 ms\ntgs=    8 threads=   1024: gpu 0.771 ms (0.96 us/dispatch), encode 0.125 ms (0.16 us/dispatch), wall 1.086 ms\ntgs=   40 threads=   5120: gpu 0.800 ms (1.00 us/dispatch), encode 0.136 ms (0.17 us/dispatch), wall 1.103 ms\ntgs=  320 threads=  40960: gpu 1.029 ms (1.29 us/dispatch), encode 0.129 ms (0.16 us/dispatch), wall 1.324 ms\ntgs= 1536 threads= 196608: gpu 1.734 ms (2.17 us/dispatch), encode 0.128 ms (0.16 us/dispatch), wall 2.023 ms\ntgs= 4096 threads= 524288: gpu 3.172 ms (3.96 us/dispatch), encode 0.182 ms (0.23 us/dispatch), wall 3.538 ms\n--- dependent kernel, concurrent encoder + memoryBarrier per dispatch ---\ntgs=    1: gpu 1.013 ms (1.27 us/dispatch)\ntgs=    8: gpu 1.053 ms (1.32 us/dispatch)\ntgs=   40: gpu 1.075 ms (1.34 us/dispatch)\ntgs=  320: gpu 1.286 ms (1.61 us/dispatch)\ntgs= 1536: gpu 2.000 ms (2.50 us/dispatch)\ntgs= 4096: gpu 3.440 ms (4.30 us/dispatch)\n--- dependent kernel, one encoder per dispatch ---\ntgs=  320: gpu 1.027 ms (1.28 us/dispatch)\n",
+ "decode_timeline_report": "decode batches: 77 (~38 tokens), dispatches/token: 897, gpu busy/token: 23.415 ms, gaps/token: 2.931 ms\nkernel                                                    n/tok    us/tok      %  us/disp  gap/tok  grids\nkernel_mul_mv_q8_0_f32                                    138.3    9613.8  41.06    69.51    399.7  124160x1x1/32x8x1 1280x1x1/32x4x1 3072x1x1/32x4x1 5120x1x1/3\nkernel_qwen4_moe_mid_q4k                                   49.2    3206.7  13.70    65.16    240.3  160x11x1/64x1x1\nkernel_qwen4_hc_gate_mix_f16                               99.4    2108.3   9.00    21.20    527.6  640x1x1/128x1x1\nkernel_qwen4_moe_down                                      49.2    1922.4   8.21    39.06    283.9  320x11x1/128x1x1\nkernel_mul_mv_f16_f32_4                                    99.4    1694.0   7.23    17.03     31.1  160x1x1/32x8x1\nkernel_qwen4_hc_norm_f16                                   98.4     952.0   4.07     9.67    255.6  32x1x1/128x1x1\nkernel_mul_mv_f32_f32_4                                    49.2     706.2   3.02    14.35    268.1  256x1x1/32x8x1\nkernel_qwen4_gdn_front                                     36.9     559.1   2.39    15.15    375.5  16x1x1/256x1x1\nkernel_qwen4_moe_reduce                                    49.2     493.2   2.11    10.02      1.9  10x1x1/256x1x1\nkernel_qwen4_router_topk                                   49.2     421.0   1.80     8.56     33.4  1x1x1/256x1x1\nkernel_qwen4_gdn_scan_r4                                   36.9     355.9   1.52     9.65      0.7  32x48x1/32x1x1\nkernel_qwen4_hc_combine                                    49.2     348.8   1.49     7.09    268.8  10x1x1/256x1x1\nkernel_qwen4_attn_decode_npt8                              12.3     293.4   1.25    23.82      0.0  2x2x1/128x1x1 3x2x1/128x1x1\nkernel_qwen4_multi_gemv                                    12.3     230.7   0.99    18.73      0.0  208x1x1/128x1x1\nkernel_qwen4_attn_prep                                     12.3     190.9   0.82    15.50    207.8  31x1x1/32x1x1\nkernel_qwen4_gdn_out                                       36.9     128.9   0.55     3.49     35.4  48x1x1/32x1x1\nkernel_qwen4_attn_merge_npt8                               12.3      60.9   0.26     4.94      1.0  24x1x1/32x1x1\nkernel_qwen4_ple_gate                                       1.0      46.4   0.20    46.38      0.0  1x1x1/256x1x1\nkernel_qwen4_idx_block_key                                  2.8      38.6   0.16    13.57      0.0  1x1x1/32x1x1\nkernel_mul_mv_q8_0_f32+kernel_dsv4_tp_keepalive             0.0      29.8   0.13  1131.25      0.0  124160x1x1/32x8x1\nkernel_qwen4_ple_conv                                       1.0       7.4   0.03     7.35      0.0  40x1x1/256x1x1\nkernel_qwen4_hc_norm_f32                                    1.0       6.5   0.03     6.37      0.0  32x1x1/128x1x1\n",
+ "gate": {
+  "builds": {
+   "baseline": {
+    "dir": "/Users/david/Documents/tools/ds4-baseline",
+    "head": "82d0314",
+    "ds4_sha256": "6be3448277c979b08eb3dc6a7457257abdcc03080e2589911b0e2d6f9d674d79",
+    "ds4_bench_sha256": "e28727691ae057e21b5279215bb940151bf978915fa6dbbf3766db13ddb676ae",
+    "metal_sha256": {
+     "argsort.metal": "0c868f5cbf751f889bb73aa5ac8599ff2b4359d9ed9aabd035043550256df790",
+     "bin.metal": "4b537679fe874fa4dea079bbb10634b3feeb2cce9b737bdb602fe6926fbb175a",
+     "concat.metal": "04fb0fc2a3b51015444e330290b979a56e4cac82aee523afa2b42e361ab23da7",
+     "cpy.metal": "53aad2024bd30543ad9d4bac3dbd718830482e76ce4f9f563fee17d558a2ac02",
+     "deepseek4_vision.metal": "c660082cb41fe767c26a396881c1b228c2d6d4b140eb09c81881efbabfd1b682",
+     "dense.metal": "03fb317ec831bbada5af603b6608a8a0d883a6540cefa581098dda894944c801",
+     "dsv4_hc.metal": "5d1988269671c9cfa9ad09024dd1c04b77559ea3894628e9bfddab44005b80d3",
+     "dsv4_kv.metal": "65e6e12ac3266fdf72b1e9c69bfbd07ea7324e930a8117b63b651b5016b1b5f6",
+     "dsv4_misc.metal": "94e48cd289bada052adbb9d84b0d4799bbc38b342ca89ade62d7a2d5cc2a37b3",
+     "dsv4_rope.metal": "f56cb24a381c27435953d120448bc22c1b2314b151280445246bd28920b4d518",
+     "flash_attn.metal": "c9ec79daf2063cd9e8c4e8874c123fbf2642c3fb6247b16aa21e1e0e6db92fcc",
+     "get_rows.metal": "bd3b352a6ffb138ae5e391db97b211f8386d417365eac2caa3730f55a075aa3a",
+     "glm53_bf16.metal": "27d93dcfe81b09f93ed65cd986aaa0b9c1ca1df7fc43e58c15da533284d50db5",
+     "glm53_kda.metal": "a695c313e36b76fa260164c6f5a2f3203748cbcff9becc6707e71aa703ed0818",
+     "glm53_vision.metal": "d20bdf039f9bd9d7b0cab8c6a4fc10bcb3097571a81246dbde1c278e0e9bec7b",
+     "glu.metal": "59281e30a27cc2eb618800b6e53a57e234f65f1a1e680d6267d9139e1a06b627",
+     "moe.metal": "f6eb2805df1d3f3691bcc6494130fbc39b3bb8d0c00dc959571161335c63fa89",
+     "norm.metal": "700bf92792e70a969c1f564c3c0ea7c8c9fe707d51a3537b766a9d336acfddd6",
+     "qwen4.metal": "85419848887cde34bed580b5da3f01fc5a2598c9e9a54301550bde402cc6e445",
+     "qwen4_vision.metal": "b37c7fc2c66131bf5817621920a6b5b30271af21160e7da33edc71e2d5c7fb4b",
+     "repeat.metal": "2c6142b47a2007d246f5eb6e7395047627bb6dfa02c649311d16620da35007cd",
+     "set_rows.metal": "25f597bf5f5fb5a3791efc68e3182539727609f09c45750ef9376ed430d7a029",
+     "softmax.metal": "6eaa6ce78c4b221b3c7fe45647d6eb42f165201992a243d77d04cf2668fb7664",
+     "sum_rows.metal": "7e1f3ad3f945b1f6f59aa2d8ee5bf464052d989a632c33ea95ce50d3c4fbf0fc",
+     "unary.metal": "56be9a0316b02d4f16cdf9487074e5a7c94215a15d9b58917e38c474cbe16dde"
+    }
+   },
+   "candidate": {
+    "dir": "/Users/david/Documents/tools/ds4-metal",
+    "head": "49b4b04",
+    "ds4_sha256": "0995b7583eb309babe54a8bfdc2310d5e6c27f884e50eeb3354f7558f92f0651",
+    "ds4_bench_sha256": "db2ab49e9d7d54447ed062a38f83a92dedd3d689f44e31ee175e0ceeddd46a60",
+    "metal_sha256": {
+     "argsort.metal": "0c868f5cbf751f889bb73aa5ac8599ff2b4359d9ed9aabd035043550256df790",
+     "bin.metal": "4b537679fe874fa4dea079bbb10634b3feeb2cce9b737bdb602fe6926fbb175a",
+     "concat.metal": "04fb0fc2a3b51015444e330290b979a56e4cac82aee523afa2b42e361ab23da7",
+     "cpy.metal": "53aad2024bd30543ad9d4bac3dbd718830482e76ce4f9f563fee17d558a2ac02",
+     "deepseek4_vision.metal": "c660082cb41fe767c26a396881c1b228c2d6d4b140eb09c81881efbabfd1b682",
+     "dense.metal": "5d643b52e47fd3e3268b9ffdc85c11034ebab008971d8840461bc5252d67045c",
+     "dsv4_hc.metal": "5d1988269671c9cfa9ad09024dd1c04b77559ea3894628e9bfddab44005b80d3",
+     "dsv4_kv.metal": "65e6e12ac3266fdf72b1e9c69bfbd07ea7324e930a8117b63b651b5016b1b5f6",
+     "dsv4_misc.metal": "94e48cd289bada052adbb9d84b0d4799bbc38b342ca89ade62d7a2d5cc2a37b3",
+     "dsv4_rope.metal": "f56cb24a381c27435953d120448bc22c1b2314b151280445246bd28920b4d518",
+     "flash_attn.metal": "c9ec79daf2063cd9e8c4e8874c123fbf2642c3fb6247b16aa21e1e0e6db92fcc",
+     "get_rows.metal": "bd3b352a6ffb138ae5e391db97b211f8386d417365eac2caa3730f55a075aa3a",
+     "glm53_bf16.metal": "27d93dcfe81b09f93ed65cd986aaa0b9c1ca1df7fc43e58c15da533284d50db5",
+     "glm53_kda.metal": "a695c313e36b76fa260164c6f5a2f3203748cbcff9becc6707e71aa703ed0818",
+     "glm53_vision.metal": "d20bdf039f9bd9d7b0cab8c6a4fc10bcb3097571a81246dbde1c278e0e9bec7b",
+     "glu.metal": "59281e30a27cc2eb618800b6e53a57e234f65f1a1e680d6267d9139e1a06b627",
+     "moe.metal": "f6eb2805df1d3f3691bcc6494130fbc39b3bb8d0c00dc959571161335c63fa89",
+     "norm.metal": "700bf92792e70a969c1f564c3c0ea7c8c9fe707d51a3537b766a9d336acfddd6",
+     "qwen4.metal": "85419848887cde34bed580b5da3f01fc5a2598c9e9a54301550bde402cc6e445",
+     "qwen4_vision.metal": "b37c7fc2c66131bf5817621920a6b5b30271af21160e7da33edc71e2d5c7fb4b",
+     "repeat.metal": "2c6142b47a2007d246f5eb6e7395047627bb6dfa02c649311d16620da35007cd",
+     "set_rows.metal": "25f597bf5f5fb5a3791efc68e3182539727609f09c45750ef9376ed430d7a029",
+     "softmax.metal": "6eaa6ce78c4b221b3c7fe45647d6eb42f165201992a243d77d04cf2668fb7664",
+     "sum_rows.metal": "7e1f3ad3f945b1f6f59aa2d8ee5bf464052d989a632c33ea95ce50d3c4fbf0fc",
+     "unary.metal": "56be9a0316b02d4f16cdf9487074e5a7c94215a15d9b58917e38c474cbe16dde"
+    }
+   }
+  },
+  "parity": {
+   "sizes": [
+    1,
+    2,
+    8,
+    9,
+    39,
+    128
+   ],
+   "checks": [
+    {
+     "prompt_tokens": 1,
+     "rows": 32,
+     "bytes": 31784960,
+     "exact": true,
+     "sha256": [
+      "f1c18decc28238c009562621ac0519d8b583209f66f20d8b78a3cac3dc9c3ab9",
+      "f1c18decc28238c009562621ac0519d8b583209f66f20d8b78a3cac3dc9c3ab9"
+     ]
+    },
+    {
+     "prompt_tokens": 2,
+     "rows": 32,
+     "bytes": 31784960,
+     "exact": true,
+     "sha256": [
+      "eacdf1c9a7c0b88c99e8490dc11895dd1b607ec575b491d4304a9c734758d747",
+      "eacdf1c9a7c0b88c99e8490dc11895dd1b607ec575b491d4304a9c734758d747"
+     ]
+    },
+    {
+     "prompt_tokens": 8,
+     "rows": 32,
+     "bytes": 31784960,
+     "exact": true,
+     "sha256": [
+      "cca091531515a2d2b82ef2a3a690e76078176ec77d2f73c22438dd2f71d21858",
+      "cca091531515a2d2b82ef2a3a690e76078176ec77d2f73c22438dd2f71d21858"
+     ]
+    },
+    {
+     "prompt_tokens": 9,
+     "rows": 32,
+     "bytes": 31784960,
+     "exact": true,
+     "sha256": [
+      "914fb74996cdf32c3c54b6c0baaaaf713af77f8ad8a6851d9f2b5337177f1062",
+      "914fb74996cdf32c3c54b6c0baaaaf713af77f8ad8a6851d9f2b5337177f1062"
+     ]
+    },
+    {
+     "prompt_tokens": 39,
+     "rows": 32,
+     "bytes": 31784960,
+     "exact": true,
+     "sha256": [
+      "b27e33a12d32cbdcc16e3f1622cbeaf50198df7ddb5aab2469a712a4bd9dd140",
+      "b27e33a12d32cbdcc16e3f1622cbeaf50198df7ddb5aab2469a712a4bd9dd140"
+     ]
+    },
+    {
+     "prompt_tokens": 128,
+     "rows": 32,
+     "bytes": 31784960,
+     "exact": true,
+     "sha256": [
+      "b625bc13c89c46349c84b3c3ff5c62587dfed4a8ec6b0285c73c5b59eda842a7",
+      "b625bc13c89c46349c84b3c3ff5c62587dfed4a8ec6b0285c73c5b59eda842a7"
+     ]
+    }
+   ],
+   "exact": true
+  },
+  "decode_cli": {
+   "plain": {
+    "summary": {
+     "hamlet": {
+      "median_tps": {
+       "baseline": 52.27,
+       "candidate": 54.67
+      },
+      "prefill_median_tps": {
+       "baseline": 132.95,
+       "candidate": 134.77
+      },
+      "range_tps": {
+       "baseline": [
+        52.23,
+        52.37
+       ],
+       "candidate": [
+        54.63,
+        54.78
+       ]
+      },
+      "speedup": 1.045915439066386,
+      "all_outputs_identical": true,
+      "acceptance_identical": true
+     },
+     "fibonacci": {
+      "median_tps": {
+       "baseline": 52.23,
+       "candidate": 54.5
+      },
+      "prefill_median_tps": {
+       "baseline": 126.92,
+       "candidate": 128.92
+      },
+      "range_tps": {
+       "baseline": [
+        51.44,
+        52.35
+       ],
+       "candidate": [
+        54.15,
+        54.79
+       ]
+      },
+      "speedup": 1.0434616121003255,
+      "all_outputs_identical": true,
+      "acceptance_identical": true
+     },
+     "explanation": {
+      "median_tps": {
+       "baseline": 52.3,
+       "candidate": 54.8
+      },
+      "prefill_median_tps": {
+       "baseline": 160.84,
+       "candidate": 163.97
+      },
+      "range_tps": {
+       "baseline": [
+        52.25,
+        52.42
+       ],
+       "candidate": [
+        54.35,
+        54.9
+       ]
+      },
+      "speedup": 1.0478011472275335,
+      "all_outputs_identical": true,
+      "acceptance_identical": true
+     }
+    },
+    "wall_s": 146.8650775839924
+   },
+   "mtp": {
+    "summary": {
+     "hamlet": {
+      "median_tps": {
+       "baseline": 63.93,
+       "candidate": 65.65
+      },
+      "prefill_median_tps": {
+       "baseline": 131.77,
+       "candidate": 134.19
+      },
+      "range_tps": {
+       "baseline": [
+        63.92,
+        64.0
+       ],
+       "candidate": [
+        65.63,
+        65.72
+       ]
+      },
+      "speedup": 1.0269044267167216,
+      "all_outputs_identical": true,
+      "acceptance_identical": true
+     },
+     "fibonacci": {
+      "median_tps": {
+       "baseline": 77.42,
+       "candidate": 79.55
+      },
+      "prefill_median_tps": {
+       "baseline": 125.96,
+       "candidate": 127.97
+      },
+      "range_tps": {
+       "baseline": [
+        75.99,
+        77.59
+       ],
+       "candidate": [
+        78.52,
+        79.64
+       ]
+      },
+      "speedup": 1.027512270731077,
+      "all_outputs_identical": true,
+      "acceptance_identical": true
+     },
+     "explanation": {
+      "median_tps": {
+       "baseline": 68.62,
+       "candidate": 70.42
+      },
+      "prefill_median_tps": {
+       "baseline": 159.86,
+       "candidate": 162.13
+      },
+      "range_tps": {
+       "baseline": [
+        67.94,
+        68.73
+       ],
+       "candidate": [
+        70.2,
+        70.42
+       ]
+      },
+      "speedup": 1.0262314194112503,
+      "all_outputs_identical": true,
+      "acceptance_identical": true
+     }
+    },
+    "wall_s": 119.7834776250238
+   }
+  },
+  "sweep_full_process_order": {
+   "ctx_max": 131072,
+   "gen_tokens": 128,
+   "runs": {
+    "r0-baseline": {
+     "rows": [
+      {
+       "ctx": 4096,
+       "prefill_tokens": 4096,
+       "prefill_tps": 1023.56,
+       "gen_tps": 49.76,
+       "gen_first_ms": 31.54,
+       "gen_steady_tps": 50.11
+      },
+      {
+       "ctx": 8192,
+       "prefill_tokens": 4096,
+       "prefill_tps": 1032.77,
+       "gen_tps": 49.66,
+       "gen_first_ms": 35.208,
+       "gen_steady_tps": 50.08
+      },
+      {
+       "ctx": 16384,
+       "prefill_tokens": 8192,
+       "prefill_tps": 1046.01,
+       "gen_tps": 49.54,
+       "gen_first_ms": 36.487,
+       "gen_steady_tps": 49.99
+      },
+      {
+       "ctx": 32768,
+       "prefill_tokens": 16384,
+       "prefill_tps": 1030.11,
+       "gen_tps": 49.43,
+       "gen_first_ms": 35.084,
+       "gen_steady_tps": 49.84
+      },
+      {
+       "ctx": 65536,
+       "prefill_tokens": 32768,
+       "prefill_tps": 1002.16,
+       "gen_tps": 49.0,
+       "gen_first_ms": 35.601,
+       "gen_steady_tps": 49.37
+      },
+      {
+       "ctx": 131072,
+       "prefill_tokens": 65536,
+       "prefill_tps": 936.0,
+       "gen_tps": 46.28,
+       "gen_first_ms": 33.772,
+       "gen_steady_tps": 46.59
+      }
+     ],
+     "logits_sha256": {
+      "frontier_004096.logits.json": "633a278db6b966867fd1df652fdad5a53e383e2f1cbd50f0a288cdbbab91c1f2",
+      "frontier_008192.logits.json": "5b7f180273ab126ecffce4ca379f7b8cb1b9ea9847a11428f72020fe3ca41253",
+      "frontier_016384.logits.json": "0ae8780e94125a74c7bff6bf1ab835294967f808488b9c3de7b0c14b6bc7f884",
+      "frontier_032768.logits.json": "3905fdccf86c5710e91838c9bfd2f1dd4b00e690fcb9d415109d1d0e537b221a",
+      "frontier_065536.logits.json": "89f966a77e1b9a5b895884bee9bd1316993a1a7d2ac6e27bfd74904d5bf2aa32",
+      "frontier_131072.logits.json": "a4621ab0b5fd03d389f3a67455c4675e0bcac52ed6a738d0b0e797bd88babfb9"
+     },
+     "wall_s": 153.50470662501175
+    },
+    "r0-candidate": {
+     "rows": [
+      {
+       "ctx": 4096,
+       "prefill_tokens": 4096,
+       "prefill_tps": 1090.42,
+       "gen_tps": 50.48,
+       "gen_first_ms": 33.939,
+       "gen_steady_tps": 50.89
+      },
+      {
+       "ctx": 8192,
+       "prefill_tokens": 4096,
+       "prefill_tps": 895.5,
+       "gen_tps": 48.67,
+       "gen_first_ms": 30.355,
+       "gen_steady_tps": 48.97
+      },
+      {
+       "ctx": 16384,
+       "prefill_tokens": 8192,
+       "prefill_tps": 922.53,
+       "gen_tps": 47.56,
+       "gen_first_ms": 38.432,
+       "gen_steady_tps": 47.98
+      },
+      {
+       "ctx": 32768,
+       "prefill_tokens": 16384,
+       "prefill_tps": 919.31,
+       "gen_tps": 47.44,
+       "gen_first_ms": 36.969,
+       "gen_steady_tps": 47.84
+      },
+      {
+       "ctx": 65536,
+       "prefill_tokens": 32768,
+       "prefill_tps": 905.08,
+       "gen_tps": 47.35,
+       "gen_first_ms": 38.167,
+       "gen_steady_tps": 47.77
+      },
+      {
+       "ctx": 131072,
+       "prefill_tokens": 65536,
+       "prefill_tps": 878.47,
+       "gen_tps": 45.67,
+       "gen_first_ms": 32.13,
+       "gen_steady_tps": 45.95
+      }
+     ],
+     "logits_sha256": {
+      "frontier_004096.logits.json": "633a278db6b966867fd1df652fdad5a53e383e2f1cbd50f0a288cdbbab91c1f2",
+      "frontier_008192.logits.json": "5b7f180273ab126ecffce4ca379f7b8cb1b9ea9847a11428f72020fe3ca41253",
+      "frontier_016384.logits.json": "0ae8780e94125a74c7bff6bf1ab835294967f808488b9c3de7b0c14b6bc7f884",
+      "frontier_032768.logits.json": "3905fdccf86c5710e91838c9bfd2f1dd4b00e690fcb9d415109d1d0e537b221a",
+      "frontier_065536.logits.json": "89f966a77e1b9a5b895884bee9bd1316993a1a7d2ac6e27bfd74904d5bf2aa32",
+      "frontier_131072.logits.json": "a4621ab0b5fd03d389f3a67455c4675e0bcac52ed6a738d0b0e797bd88babfb9"
+     },
+     "wall_s": 165.39884799998254
+    },
+    "r1-candidate": {
+     "rows": [
+      {
+       "ctx": 4096,
+       "prefill_tokens": 4096,
+       "prefill_tps": 1039.42,
+       "gen_tps": 47.18,
+       "gen_first_ms": 31.224,
+       "gen_steady_tps": 47.47
+      },
+      {
+       "ctx": 8192,
+       "prefill_tokens": 4096,
+       "prefill_tps": 843.58,
+       "gen_tps": 47.49,
+       "gen_first_ms": 36.68,
+       "gen_steady_tps": 47.89
+      },
+      {
+       "ctx": 16384,
+       "prefill_tokens": 8192,
+       "prefill_tps": 877.76,
+       "gen_tps": 46.87,
+       "gen_first_ms": 38.425,
+       "gen_steady_tps": 47.28
+      },
+      {
+       "ctx": 32768,
+       "prefill_tokens": 16384,
+       "prefill_tps": 881.3,
+       "gen_tps": 46.55,
+       "gen_first_ms": 36.614,
+       "gen_steady_tps": 46.92
+      },
+      {
+       "ctx": 65536,
+       "prefill_tokens": 32768,
+       "prefill_tps": 875.59,
+       "gen_tps": 47.16,
+       "gen_first_ms": 37.487,
+       "gen_steady_tps": 47.56
+      },
+      {
+       "ctx": 131072,
+       "prefill_tokens": 65536,
+       "prefill_tps": 859.84,
+       "gen_tps": 44.07,
+       "gen_first_ms": 33.282,
+       "gen_steady_tps": 44.33
+      }
+     ],
+     "logits_sha256": {
+      "frontier_004096.logits.json": "633a278db6b966867fd1df652fdad5a53e383e2f1cbd50f0a288cdbbab91c1f2",
+      "frontier_008192.logits.json": "5b7f180273ab126ecffce4ca379f7b8cb1b9ea9847a11428f72020fe3ca41253",
+      "frontier_016384.logits.json": "0ae8780e94125a74c7bff6bf1ab835294967f808488b9c3de7b0c14b6bc7f884",
+      "frontier_032768.logits.json": "3905fdccf86c5710e91838c9bfd2f1dd4b00e690fcb9d415109d1d0e537b221a",
+      "frontier_065536.logits.json": "89f966a77e1b9a5b895884bee9bd1316993a1a7d2ac6e27bfd74904d5bf2aa32",
+      "frontier_131072.logits.json": "a4621ab0b5fd03d389f3a67455c4675e0bcac52ed6a738d0b0e797bd88babfb9"
+     },
+     "wall_s": 170.21601658299915
+    },
+    "r1-baseline": {
+     "rows": [
+      {
+       "ctx": 4096,
+       "prefill_tokens": 4096,
+       "prefill_tps": 1004.2,
+       "gen_tps": 45.0,
+       "gen_first_ms": 36.785,
+       "gen_steady_tps": 45.33
+      },
+      {
+       "ctx": 8192,
+       "prefill_tokens": 4096,
+       "prefill_tps": 819.85,
+       "gen_tps": 45.55,
+       "gen_first_ms": 37.855,
+       "gen_steady_tps": 45.92
+      },
+      {
+       "ctx": 16384,
+       "prefill_tokens": 8192,
+       "prefill_tps": 855.88,
+       "gen_tps": 44.9,
+       "gen_first_ms": 37.184,
+       "gen_steady_tps": 45.23
+      },
+      {
+       "ctx": 32768,
+       "prefill_tokens": 16384,
+       "prefill_tps": 859.93,
+       "gen_tps": 45.42,
+       "gen_first_ms": 39.526,
+       "gen_steady_tps": 45.81
+      },
+      {
+       "ctx": 65536,
+       "prefill_tokens": 32768,
+       "prefill_tps": 859.34,
+       "gen_tps": 44.45,
+       "gen_first_ms": 38.348,
+       "gen_steady_tps": 44.79
+      },
+      {
+       "ctx": 131072,
+       "prefill_tokens": 65536,
+       "prefill_tps": 842.91,
+       "gen_tps": 43.02,
+       "gen_first_ms": 34.724,
+       "gen_steady_tps": 43.28
+      }
+     ],
+     "logits_sha256": {
+      "frontier_004096.logits.json": "633a278db6b966867fd1df652fdad5a53e383e2f1cbd50f0a288cdbbab91c1f2",
+      "frontier_008192.logits.json": "5b7f180273ab126ecffce4ca379f7b8cb1b9ea9847a11428f72020fe3ca41253",
+      "frontier_016384.logits.json": "0ae8780e94125a74c7bff6bf1ab835294967f808488b9c3de7b0c14b6bc7f884",
+      "frontier_032768.logits.json": "3905fdccf86c5710e91838c9bfd2f1dd4b00e690fcb9d415109d1d0e537b221a",
+      "frontier_065536.logits.json": "89f966a77e1b9a5b895884bee9bd1316993a1a7d2ac6e27bfd74904d5bf2aa32",
+      "frontier_131072.logits.json": "a4621ab0b5fd03d389f3a67455c4675e0bcac52ed6a738d0b0e797bd88babfb9"
+     },
+     "wall_s": 174.1835533340054
+    }
+   },
+   "table": [
+    {
+     "ctx": 4096,
+     "baseline": {
+      "prefill_tps": 1013.88,
+      "gen_tps": 47.379999999999995,
+      "gen_steady_tps": 47.72
+     },
+     "candidate": {
+      "prefill_tps": 1064.92,
+      "gen_tps": 48.83,
+      "gen_steady_tps": 49.18
+     },
+     "prefill_pct": 5.034126326586974,
+     "decode_pct": 3.0603630223723144
+    },
+    {
+     "ctx": 8192,
+     "baseline": {
+      "prefill_tps": 926.31,
+      "gen_tps": 47.605,
+      "gen_steady_tps": 48.0
+     },
+     "candidate": {
+      "prefill_tps": 869.54,
+      "gen_tps": 48.08,
+      "gen_steady_tps": 48.43
+     },
+     "prefill_pct": -6.1286178493160985,
+     "decode_pct": 0.9977943493330477
+    },
+    {
+     "ctx": 16384,
+     "baseline": {
+      "prefill_tps": 950.9449999999999,
+      "gen_tps": 47.22,
+      "gen_steady_tps": 47.61
+     },
+     "candidate": {
+      "prefill_tps": 900.145,
+      "gen_tps": 47.215,
+      "gen_steady_tps": 47.629999999999995
+     },
+     "prefill_pct": -5.342054482646208,
+     "decode_pct": -0.01058873358745771
+    },
+    {
+     "ctx": 32768,
+     "baseline": {
+      "prefill_tps": 945.02,
+      "gen_tps": 47.425,
+      "gen_steady_tps": 47.825
+     },
+     "candidate": {
+      "prefill_tps": 900.305,
+      "gen_tps": 46.995,
+      "gen_steady_tps": 47.38
+     },
+     "prefill_pct": -4.731645891092251,
+     "decode_pct": -0.9066947812335302
+    },
+    {
+     "ctx": 65536,
+     "baseline": {
+      "prefill_tps": 930.75,
+      "gen_tps": 46.725,
+      "gen_steady_tps": 47.08
+     },
+     "candidate": {
+      "prefill_tps": 890.335,
+      "gen_tps": 47.254999999999995,
+      "gen_steady_tps": 47.665000000000006
+     },
+     "prefill_pct": -4.342197152833737,
+     "decode_pct": 1.1342964151952684
+    },
+    {
+     "ctx": 131072,
+     "baseline": {
+      "prefill_tps": 889.4549999999999,
+      "gen_tps": 44.650000000000006,
+      "gen_steady_tps": 44.935
+     },
+     "candidate": {
+      "prefill_tps": 869.155,
+      "gen_tps": 44.870000000000005,
+      "gen_steady_tps": 45.14
+     },
+     "prefill_pct": -2.2822964624404807,
+     "decode_pct": 0.492721164613652
+    }
+   ],
+   "frontier_logits_exact": true,
+   "frontiers_compared": 6
+  },
+  "exact": true
+ },
+ "per_frontier_sweeps": {
+  "sweep-round1-long": {
+   "builds": {
+    "baseline": {
+     "dir": "/Users/david/Documents/tools/ds4-baseline",
+     "head": "82d0314",
+     "ds4_sha256": "6be3448277c979b08eb3dc6a7457257abdcc03080e2589911b0e2d6f9d674d79",
+     "ds4_bench_sha256": "e28727691ae057e21b5279215bb940151bf978915fa6dbbf3766db13ddb676ae",
+     "metal_sha256": {
+      "argsort.metal": "0c868f5cbf751f889bb73aa5ac8599ff2b4359d9ed9aabd035043550256df790",
+      "bin.metal": "4b537679fe874fa4dea079bbb10634b3feeb2cce9b737bdb602fe6926fbb175a",
+      "concat.metal": "04fb0fc2a3b51015444e330290b979a56e4cac82aee523afa2b42e361ab23da7",
+      "cpy.metal": "53aad2024bd30543ad9d4bac3dbd718830482e76ce4f9f563fee17d558a2ac02",
+      "deepseek4_vision.metal": "c660082cb41fe767c26a396881c1b228c2d6d4b140eb09c81881efbabfd1b682",
+      "dense.metal": "03fb317ec831bbada5af603b6608a8a0d883a6540cefa581098dda894944c801",
+      "dsv4_hc.metal": "5d1988269671c9cfa9ad09024dd1c04b77559ea3894628e9bfddab44005b80d3",
+      "dsv4_kv.metal": "65e6e12ac3266fdf72b1e9c69bfbd07ea7324e930a8117b63b651b5016b1b5f6",
+      "dsv4_misc.metal": "94e48cd289bada052adbb9d84b0d4799bbc38b342ca89ade62d7a2d5cc2a37b3",
+      "dsv4_rope.metal": "f56cb24a381c27435953d120448bc22c1b2314b151280445246bd28920b4d518",
+      "flash_attn.metal": "c9ec79daf2063cd9e8c4e8874c123fbf2642c3fb6247b16aa21e1e0e6db92fcc",
+      "get_rows.metal": "bd3b352a6ffb138ae5e391db97b211f8386d417365eac2caa3730f55a075aa3a",
+      "glm53_bf16.metal": "27d93dcfe81b09f93ed65cd986aaa0b9c1ca1df7fc43e58c15da533284d50db5",
+      "glm53_kda.metal": "a695c313e36b76fa260164c6f5a2f3203748cbcff9becc6707e71aa703ed0818",
+      "glm53_vision.metal": "d20bdf039f9bd9d7b0cab8c6a4fc10bcb3097571a81246dbde1c278e0e9bec7b",
+      "glu.metal": "59281e30a27cc2eb618800b6e53a57e234f65f1a1e680d6267d9139e1a06b627",
+      "moe.metal": "f6eb2805df1d3f3691bcc6494130fbc39b3bb8d0c00dc959571161335c63fa89",
+      "norm.metal": "700bf92792e70a969c1f564c3c0ea7c8c9fe707d51a3537b766a9d336acfddd6",
+      "qwen4.metal": "85419848887cde34bed580b5da3f01fc5a2598c9e9a54301550bde402cc6e445",
+      "qwen4_vision.metal": "b37c7fc2c66131bf5817621920a6b5b30271af21160e7da33edc71e2d5c7fb4b",
+      "repeat.metal": "2c6142b47a2007d246f5eb6e7395047627bb6dfa02c649311d16620da35007cd",
+      "set_rows.metal": "25f597bf5f5fb5a3791efc68e3182539727609f09c45750ef9376ed430d7a029",
+      "softmax.metal": "6eaa6ce78c4b221b3c7fe45647d6eb42f165201992a243d77d04cf2668fb7664",
+      "sum_rows.metal": "7e1f3ad3f945b1f6f59aa2d8ee5bf464052d989a632c33ea95ce50d3c4fbf0fc",
+      "unary.metal": "56be9a0316b02d4f16cdf9487074e5a7c94215a15d9b58917e38c474cbe16dde"
+     }
+    },
+    "candidate": {
+     "dir": "/Users/david/Documents/tools/ds4-metal",
+     "head": "49b4b04",
+     "ds4_sha256": "c22e718643c1c977a18e0124ced2dad2a38c3e074d3ed27c1f991a393a63870d",
+     "ds4_bench_sha256": "189da81226d334c347fb46f0bd8464979bc1fbfc1ff8f2ff2a5f6adbc4ffa8cb",
+     "metal_sha256": {
+      "argsort.metal": "0c868f5cbf751f889bb73aa5ac8599ff2b4359d9ed9aabd035043550256df790",
+      "bin.metal": "4b537679fe874fa4dea079bbb10634b3feeb2cce9b737bdb602fe6926fbb175a",
+      "concat.metal": "04fb0fc2a3b51015444e330290b979a56e4cac82aee523afa2b42e361ab23da7",
+      "cpy.metal": "53aad2024bd30543ad9d4bac3dbd718830482e76ce4f9f563fee17d558a2ac02",
+      "deepseek4_vision.metal": "c660082cb41fe767c26a396881c1b228c2d6d4b140eb09c81881efbabfd1b682",
+      "dense.metal": "03fb317ec831bbada5af603b6608a8a0d883a6540cefa581098dda894944c801",
+      "dsv4_hc.metal": "5d1988269671c9cfa9ad09024dd1c04b77559ea3894628e9bfddab44005b80d3",
+      "dsv4_kv.metal": "65e6e12ac3266fdf72b1e9c69bfbd07ea7324e930a8117b63b651b5016b1b5f6",
+      "dsv4_misc.metal": "94e48cd289bada052adbb9d84b0d4799bbc38b342ca89ade62d7a2d5cc2a37b3",
+      "dsv4_rope.metal": "f56cb24a381c27435953d120448bc22c1b2314b151280445246bd28920b4d518",
+      "flash_attn.metal": "c9ec79daf2063cd9e8c4e8874c123fbf2642c3fb6247b16aa21e1e0e6db92fcc",
+      "get_rows.metal": "bd3b352a6ffb138ae5e391db97b211f8386d417365eac2caa3730f55a075aa3a",
+      "glm53_bf16.metal": "27d93dcfe81b09f93ed65cd986aaa0b9c1ca1df7fc43e58c15da533284d50db5",
+      "glm53_kda.metal": "a695c313e36b76fa260164c6f5a2f3203748cbcff9becc6707e71aa703ed0818",
+      "glm53_vision.metal": "d20bdf039f9bd9d7b0cab8c6a4fc10bcb3097571a81246dbde1c278e0e9bec7b",
+      "glu.metal": "59281e30a27cc2eb618800b6e53a57e234f65f1a1e680d6267d9139e1a06b627",
+      "moe.metal": "f6eb2805df1d3f3691bcc6494130fbc39b3bb8d0c00dc959571161335c63fa89",
+      "norm.metal": "700bf92792e70a969c1f564c3c0ea7c8c9fe707d51a3537b766a9d336acfddd6",
+      "qwen4.metal": "85419848887cde34bed580b5da3f01fc5a2598c9e9a54301550bde402cc6e445",
+      "qwen4_vision.metal": "b37c7fc2c66131bf5817621920a6b5b30271af21160e7da33edc71e2d5c7fb4b",
+      "repeat.metal": "2c6142b47a2007d246f5eb6e7395047627bb6dfa02c649311d16620da35007cd",
+      "set_rows.metal": "25f597bf5f5fb5a3791efc68e3182539727609f09c45750ef9376ed430d7a029",
+      "softmax.metal": "6eaa6ce78c4b221b3c7fe45647d6eb42f165201992a243d77d04cf2668fb7664",
+      "sum_rows.metal": "7e1f3ad3f945b1f6f59aa2d8ee5bf464052d989a632c33ea95ce50d3c4fbf0fc",
+      "unary.metal": "56be9a0316b02d4f16cdf9487074e5a7c94215a15d9b58917e38c474cbe16dde"
+     }
+    }
+   },
+   "sweep": {
+    "gen_tokens": 128,
+    "runs": {
+     "c32768-s0-baseline": {
+      "row": {
+       "ctx": 32768,
+       "prefill_tokens": 32768,
+       "prefill_tps": 903.7,
+       "gen_tps": 46.81,
+       "gen_first_ms": 34.912,
+       "gen_steady_tps": 47.16
+      },
+      "logits_sha256": {
+       "frontier_032768.logits.json": "f97f2ae79b2eb81e17462dd1aa31412703beb5663e65c79b7b04a8986ee807ac"
+      },
+      "wall_s": 56.606673958012834
+     },
+     "c32768-s1-candidate": {
+      "row": {
+       "ctx": 32768,
+       "prefill_tokens": 32768,
+       "prefill_tps": 944.35,
+       "gen_tps": 48.0,
+       "gen_first_ms": 33.97,
+       "gen_steady_tps": 48.36
+      },
+      "logits_sha256": {
+       "frontier_032768.logits.json": "f97f2ae79b2eb81e17462dd1aa31412703beb5663e65c79b7b04a8986ee807ac"
+      },
+      "wall_s": 40.25732545898063
+     },
+     "c32768-s2-candidate": {
+      "row": {
+       "ctx": 32768,
+       "prefill_tokens": 32768,
+       "prefill_tps": 932.54,
+       "gen_tps": 46.98,
+       "gen_first_ms": 34.269,
+       "gen_steady_tps": 47.32
+      },
+      "logits_sha256": {
+       "frontier_032768.logits.json": "f97f2ae79b2eb81e17462dd1aa31412703beb5663e65c79b7b04a8986ee807ac"
+      },
+      "wall_s": 40.51659883299726
+     },
+     "c32768-s3-baseline": {
+      "row": {
+       "ctx": 32768,
+       "prefill_tokens": 32768,
+       "prefill_tps": 909.52,
+       "gen_tps": 45.55,
+       "gen_first_ms": 33.702,
+       "gen_steady_tps": 45.84
+      },
+      "logits_sha256": {
+       "frontier_032768.logits.json": "f97f2ae79b2eb81e17462dd1aa31412703beb5663e65c79b7b04a8986ee807ac"
+      },
+      "wall_s": 41.45747166601359
+     },
+     "c131072-s0-baseline": {
+      "row": {
+       "ctx": 131072,
+       "prefill_tokens": 131072,
+       "prefill_tps": 867.77,
+       "gen_tps": 42.92,
+       "gen_first_ms": 35.184,
+       "gen_steady_tps": 43.19
+      },
+      "logits_sha256": {
+       "frontier_131072.logits.json": "5b2ac11d89146947e6672b88e2a813f3aa31dcd38be2ea6df7a019f1cd107763"
+      },
+      "wall_s": 156.7620229999884
+     },
+     "c131072-s1-candidate": {
+      "row": {
+       "ctx": 131072,
+       "prefill_tokens": 131072,
+       "prefill_tps": 869.83,
+       "gen_tps": 44.11,
+       "gen_first_ms": 33.482,
+       "gen_steady_tps": 44.38
+      },
+      "logits_sha256": {
+       "frontier_131072.logits.json": "5b2ac11d89146947e6672b88e2a813f3aa31dcd38be2ea6df7a019f1cd107763"
+      },
+      "wall_s": 156.3090578749834
+     },
+     "c131072-s2-candidate": {
+      "row": {
+       "ctx": 131072,
+       "prefill_tokens": 131072,
+       "prefill_tps": 866.39,
+       "gen_tps": 44.66,
+       "gen_first_ms": 33.489,
+       "gen_steady_tps": 44.93
+      },
+      "logits_sha256": {
+       "frontier_131072.logits.json": "5b2ac11d89146947e6672b88e2a813f3aa31dcd38be2ea6df7a019f1cd107763"
+      },
+      "wall_s": 156.86479266700917
+     },
+     "c131072-s3-baseline": {
+      "row": {
+       "ctx": 131072,
+       "prefill_tokens": 131072,
+       "prefill_tps": 860.37,
+       "gen_tps": 43.01,
+       "gen_first_ms": 36.049,
+       "gen_steady_tps": 43.29
+      },
+      "logits_sha256": {
+       "frontier_131072.logits.json": "5b2ac11d89146947e6672b88e2a813f3aa31dcd38be2ea6df7a019f1cd107763"
+      },
+      "wall_s": 158.0716283340007
+     }
+    },
+    "table": [
+     {
+      "ctx": 32768,
+      "exact": true,
+      "baseline": {
+       "prefill_tps": 906.61,
+       "gen_tps": 46.18,
+       "gen_steady_tps": 46.5
+      },
+      "candidate": {
+       "prefill_tps": 938.4449999999999,
+       "gen_tps": 47.489999999999995,
+       "gen_steady_tps": 47.84
+      },
+      "prefill_pct": 3.5114326998378464,
+      "decode_pct": 2.8367258553486208
+     },
+     {
+      "ctx": 131072,
+      "exact": true,
+      "baseline": {
+       "prefill_tps": 864.0699999999999,
+       "gen_tps": 42.965,
+       "gen_steady_tps": 43.239999999999995
+      },
+      "candidate": {
+       "prefill_tps": 868.11,
+       "gen_tps": 44.385,
+       "gen_steady_tps": 44.655
+      },
+      "prefill_pct": 0.46755471200250476,
+      "decode_pct": 3.3050157104620004
+     }
+    ],
+    "frontier_logits_exact": true,
+    "frontiers_compared": 2
+   }
+  },
+  "sweep-round1b": {
+   "builds": {
+    "baseline": {
+     "dir": "/Users/david/Documents/tools/ds4-baseline",
+     "head": "82d0314",
+     "ds4_sha256": "6be3448277c979b08eb3dc6a7457257abdcc03080e2589911b0e2d6f9d674d79",
+     "ds4_bench_sha256": "e28727691ae057e21b5279215bb940151bf978915fa6dbbf3766db13ddb676ae",
+     "metal_sha256": {
+      "argsort.metal": "0c868f5cbf751f889bb73aa5ac8599ff2b4359d9ed9aabd035043550256df790",
+      "bin.metal": "4b537679fe874fa4dea079bbb10634b3feeb2cce9b737bdb602fe6926fbb175a",
+      "concat.metal": "04fb0fc2a3b51015444e330290b979a56e4cac82aee523afa2b42e361ab23da7",
+      "cpy.metal": "53aad2024bd30543ad9d4bac3dbd718830482e76ce4f9f563fee17d558a2ac02",
+      "deepseek4_vision.metal": "c660082cb41fe767c26a396881c1b228c2d6d4b140eb09c81881efbabfd1b682",
+      "dense.metal": "03fb317ec831bbada5af603b6608a8a0d883a6540cefa581098dda894944c801",
+      "dsv4_hc.metal": "5d1988269671c9cfa9ad09024dd1c04b77559ea3894628e9bfddab44005b80d3",
+      "dsv4_kv.metal": "65e6e12ac3266fdf72b1e9c69bfbd07ea7324e930a8117b63b651b5016b1b5f6",
+      "dsv4_misc.metal": "94e48cd289bada052adbb9d84b0d4799bbc38b342ca89ade62d7a2d5cc2a37b3",
+      "dsv4_rope.metal": "f56cb24a381c27435953d120448bc22c1b2314b151280445246bd28920b4d518",
+      "flash_attn.metal": "c9ec79daf2063cd9e8c4e8874c123fbf2642c3fb6247b16aa21e1e0e6db92fcc",
+      "get_rows.metal": "bd3b352a6ffb138ae5e391db97b211f8386d417365eac2caa3730f55a075aa3a",
+      "glm53_bf16.metal": "27d93dcfe81b09f93ed65cd986aaa0b9c1ca1df7fc43e58c15da533284d50db5",
+      "glm53_kda.metal": "a695c313e36b76fa260164c6f5a2f3203748cbcff9becc6707e71aa703ed0818",
+      "glm53_vision.metal": "d20bdf039f9bd9d7b0cab8c6a4fc10bcb3097571a81246dbde1c278e0e9bec7b",
+      "glu.metal": "59281e30a27cc2eb618800b6e53a57e234f65f1a1e680d6267d9139e1a06b627",
+      "moe.metal": "f6eb2805df1d3f3691bcc6494130fbc39b3bb8d0c00dc959571161335c63fa89",
+      "norm.metal": "700bf92792e70a969c1f564c3c0ea7c8c9fe707d51a3537b766a9d336acfddd6",
+      "qwen4.metal": "85419848887cde34bed580b5da3f01fc5a2598c9e9a54301550bde402cc6e445",
+      "qwen4_vision.metal": "b37c7fc2c66131bf5817621920a6b5b30271af21160e7da33edc71e2d5c7fb4b",
+      "repeat.metal": "2c6142b47a2007d246f5eb6e7395047627bb6dfa02c649311d16620da35007cd",
+      "set_rows.metal": "25f597bf5f5fb5a3791efc68e3182539727609f09c45750ef9376ed430d7a029",
+      "softmax.metal": "6eaa6ce78c4b221b3c7fe45647d6eb42f165201992a243d77d04cf2668fb7664",
+      "sum_rows.metal": "7e1f3ad3f945b1f6f59aa2d8ee5bf464052d989a632c33ea95ce50d3c4fbf0fc",
+      "unary.metal": "56be9a0316b02d4f16cdf9487074e5a7c94215a15d9b58917e38c474cbe16dde"
+     }
+    },
+    "candidate": {
+     "dir": "/Users/david/Documents/tools/ds4-metal",
+     "head": "56bbb18",
+     "ds4_sha256": "26bd8b62290af9eb3e1d4646eaf38e8460de2aff4a88c3b1ea90f757148a61a7",
+     "ds4_bench_sha256": "b4366b53d169fd6be0d7f5f1d3f90bcec694da3fcef546a027dd280c4e446df9",
+     "metal_sha256": {
+      "argsort.metal": "0c868f5cbf751f889bb73aa5ac8599ff2b4359d9ed9aabd035043550256df790",
+      "bin.metal": "4b537679fe874fa4dea079bbb10634b3feeb2cce9b737bdb602fe6926fbb175a",
+      "concat.metal": "04fb0fc2a3b51015444e330290b979a56e4cac82aee523afa2b42e361ab23da7",
+      "cpy.metal": "53aad2024bd30543ad9d4bac3dbd718830482e76ce4f9f563fee17d558a2ac02",
+      "deepseek4_vision.metal": "c660082cb41fe767c26a396881c1b228c2d6d4b140eb09c81881efbabfd1b682",
+      "dense.metal": "03fb317ec831bbada5af603b6608a8a0d883a6540cefa581098dda894944c801",
+      "dsv4_hc.metal": "5d1988269671c9cfa9ad09024dd1c04b77559ea3894628e9bfddab44005b80d3",
+      "dsv4_kv.metal": "65e6e12ac3266fdf72b1e9c69bfbd07ea7324e930a8117b63b651b5016b1b5f6",
+      "dsv4_misc.metal": "94e48cd289bada052adbb9d84b0d4799bbc38b342ca89ade62d7a2d5cc2a37b3",
+      "dsv4_rope.metal": "f56cb24a381c27435953d120448bc22c1b2314b151280445246bd28920b4d518",
+      "flash_attn.metal": "c9ec79daf2063cd9e8c4e8874c123fbf2642c3fb6247b16aa21e1e0e6db92fcc",
+      "get_rows.metal": "bd3b352a6ffb138ae5e391db97b211f8386d417365eac2caa3730f55a075aa3a",
+      "glm53_bf16.metal": "27d93dcfe81b09f93ed65cd986aaa0b9c1ca1df7fc43e58c15da533284d50db5",
+      "glm53_kda.metal": "a695c313e36b76fa260164c6f5a2f3203748cbcff9becc6707e71aa703ed0818",
+      "glm53_vision.metal": "d20bdf039f9bd9d7b0cab8c6a4fc10bcb3097571a81246dbde1c278e0e9bec7b",
+      "glu.metal": "59281e30a27cc2eb618800b6e53a57e234f65f1a1e680d6267d9139e1a06b627",
+      "moe.metal": "f6eb2805df1d3f3691bcc6494130fbc39b3bb8d0c00dc959571161335c63fa89",
+      "norm.metal": "700bf92792e70a969c1f564c3c0ea7c8c9fe707d51a3537b766a9d336acfddd6",
+      "qwen4.metal": "85419848887cde34bed580b5da3f01fc5a2598c9e9a54301550bde402cc6e445",
+      "qwen4_vision.metal": "b37c7fc2c66131bf5817621920a6b5b30271af21160e7da33edc71e2d5c7fb4b",
+      "repeat.metal": "2c6142b47a2007d246f5eb6e7395047627bb6dfa02c649311d16620da35007cd",
+      "set_rows.metal": "25f597bf5f5fb5a3791efc68e3182539727609f09c45750ef9376ed430d7a029",
+      "softmax.metal": "6eaa6ce78c4b221b3c7fe45647d6eb42f165201992a243d77d04cf2668fb7664",
+      "sum_rows.metal": "7e1f3ad3f945b1f6f59aa2d8ee5bf464052d989a632c33ea95ce50d3c4fbf0fc",
+      "unary.metal": "56be9a0316b02d4f16cdf9487074e5a7c94215a15d9b58917e38c474cbe16dde"
+     }
+    }
+   },
+   "sweep": {
+    "gen_tokens": 128,
+    "runs": {
+     "c4096-s0-baseline": {
+      "row": {
+       "ctx": 4096,
+       "prefill_tokens": 4096,
+       "prefill_tps": 978.51,
+       "gen_tps": 49.49,
+       "gen_first_ms": 29.687,
+       "gen_steady_tps": 49.8
+      },
+      "logits_sha256": {
+       "frontier_004096.logits.json": "a3361eccef5a8355fa98129328aaedba15dd0d8bf17f685b190f83c2664c58ad"
+      },
+      "wall_s": 21.381870792014524
+     },
+     "c4096-s1-candidate": {
+      "row": {
+       "ctx": 4096,
+       "prefill_tokens": 4096,
+       "prefill_tps": 1167.6,
+       "gen_tps": 52.1,
+       "gen_first_ms": 23.934,
+       "gen_steady_tps": 52.33
+      },
+      "logits_sha256": {
+       "frontier_004096.logits.json": "a3361eccef5a8355fa98129328aaedba15dd0d8bf17f685b190f83c2664c58ad"
+      },
+      "wall_s": 8.631771208980354
+     },
+     "c4096-s2-candidate": {
+      "row": {
+       "ctx": 4096,
+       "prefill_tokens": 4096,
+       "prefill_tps": 1168.43,
+       "gen_tps": 52.21,
+       "gen_first_ms": 24.241,
+       "gen_steady_tps": 52.45
+      },
+      "logits_sha256": {
+       "frontier_004096.logits.json": "a3361eccef5a8355fa98129328aaedba15dd0d8bf17f685b190f83c2664c58ad"
+      },
+      "wall_s": 8.431311416003155
+     },
+     "c4096-s3-baseline": {
+      "row": {
+       "ctx": 4096,
+       "prefill_tokens": 4096,
+       "prefill_tps": 1094.21,
+       "gen_tps": 49.92,
+       "gen_first_ms": 23.886,
+       "gen_steady_tps": 50.12
+      },
+      "logits_sha256": {
+       "frontier_004096.logits.json": "a3361eccef5a8355fa98129328aaedba15dd0d8bf17f685b190f83c2664c58ad"
+      },
+      "wall_s": 8.76690841600066
+     },
+     "c32768-s0-baseline": {
+      "row": {
+       "ctx": 32768,
+       "prefill_tokens": 32768,
+       "prefill_tps": 980.94,
+       "gen_tps": 49.34,
+       "gen_first_ms": 31.347,
+       "gen_steady_tps": 49.68
+      },
+      "logits_sha256": {
+       "frontier_032768.logits.json": "f97f2ae79b2eb81e17462dd1aa31412703beb5663e65c79b7b04a8986ee807ac"
+      },
+      "wall_s": 38.65127445899998
+     },
+     "c32768-s1-candidate": {
+      "row": {
+       "ctx": 32768,
+       "prefill_tokens": 32768,
+       "prefill_tps": 1061.33,
+       "gen_tps": 51.03,
+       "gen_first_ms": 31.296,
+       "gen_steady_tps": 51.4
+      },
+      "logits_sha256": {
+       "frontier_032768.logits.json": "f97f2ae79b2eb81e17462dd1aa31412703beb5663e65c79b7b04a8986ee807ac"
+      },
+      "wall_s": 36.01488224999048
+     },
+     "c32768-s2-candidate": {
+      "row": {
+       "ctx": 32768,
+       "prefill_tokens": 32768,
+       "prefill_tps": 1032.15,
+       "gen_tps": 49.15,
+       "gen_first_ms": 30.901,
+       "gen_steady_tps": 49.48
+      },
+      "logits_sha256": {
+       "frontier_032768.logits.json": "f97f2ae79b2eb81e17462dd1aa31412703beb5663e65c79b7b04a8986ee807ac"
+      },
+      "wall_s": 36.98131854197709
+     },
+     "c32768-s3-baseline": {
+      "row": {
+       "ctx": 32768,
+       "prefill_tokens": 32768,
+       "prefill_tps": 911.37,
+       "gen_tps": 46.08,
+       "gen_first_ms": 31.431,
+       "gen_steady_tps": 46.35
+      },
+      "logits_sha256": {
+       "frontier_032768.logits.json": "f97f2ae79b2eb81e17462dd1aa31412703beb5663e65c79b7b04a8986ee807ac"
+      },
+      "wall_s": 41.31892995801172
+     },
+     "c131072-s0-baseline": {
+      "row": {
+       "ctx": 131072,
+       "prefill_tokens": 131072,
+       "prefill_tps": 847.31,
+       "gen_tps": 43.1,
+       "gen_first_ms": 33.804,
+       "gen_steady_tps": 43.35
+      },
+      "logits_sha256": {
+       "frontier_131072.logits.json": "5b2ac11d89146947e6672b88e2a813f3aa31dcd38be2ea6df7a019f1cd107763"
+      },
+      "wall_s": 160.39675341700786
+     },
+     "c131072-s1-candidate": {
+      "row": {
+       "ctx": 131072,
+       "prefill_tokens": 131072,
+       "prefill_tps": 893.39,
+       "gen_tps": 45.13,
+       "gen_first_ms": 30.661,
+       "gen_steady_tps": 45.35
+      },
+      "logits_sha256": {
+       "frontier_131072.logits.json": "5b2ac11d89146947e6672b88e2a813f3aa31dcd38be2ea6df7a019f1cd107763"
+      },
+      "wall_s": 152.27351208298933
+     },
+     "c131072-s2-candidate": {
+      "row": {
+       "ctx": 131072,
+       "prefill_tokens": 131072,
+       "prefill_tps": 889.67,
+       "gen_tps": 44.85,
+       "gen_first_ms": 31.596,
+       "gen_steady_tps": 45.08
+      },
+      "logits_sha256": {
+       "frontier_131072.logits.json": "5b2ac11d89146947e6672b88e2a813f3aa31dcd38be2ea6df7a019f1cd107763"
+      },
+      "wall_s": 152.89552341602393
+     },
+     "c131072-s3-baseline": {
+      "row": {
+       "ctx": 131072,
+       "prefill_tokens": 131072,
+       "prefill_tps": 831.19,
+       "gen_tps": 42.6,
+       "gen_first_ms": 32.993,
+       "gen_steady_tps": 42.82
+      },
+      "logits_sha256": {
+       "frontier_131072.logits.json": "5b2ac11d89146947e6672b88e2a813f3aa31dcd38be2ea6df7a019f1cd107763"
+      },
+      "wall_s": 163.45226291698054
+     }
+    },
+    "table": [
+     {
+      "ctx": 4096,
+      "exact": true,
+      "baseline": {
+       "prefill_tps": 1036.3600000000001,
+       "gen_tps": 49.705,
+       "gen_steady_tps": 49.959999999999994
+      },
+      "candidate": {
+       "prefill_tps": 1168.0149999999999,
+       "gen_tps": 52.155,
+       "gen_steady_tps": 52.39
+      },
+      "prefill_pct": 12.703597205604211,
+      "decode_pct": 4.929081581329853
+     },
+     {
+      "ctx": 32768,
+      "exact": true,
+      "baseline": {
+       "prefill_tps": 946.155,
+       "gen_tps": 47.71,
+       "gen_steady_tps": 48.015
+      },
+      "candidate": {
+       "prefill_tps": 1046.74,
+       "gen_tps": 50.09,
+       "gen_steady_tps": 50.44
+      },
+      "prefill_pct": 10.63092199481057,
+      "decode_pct": 4.988472018444767
+     },
+     {
+      "ctx": 131072,
+      "exact": true,
+      "baseline": {
+       "prefill_tps": 839.25,
+       "gen_tps": 42.85,
+       "gen_steady_tps": 43.085
+      },
+      "candidate": {
+       "prefill_tps": 891.53,
+       "gen_tps": 44.99,
+       "gen_steady_tps": 45.215
+      },
+      "prefill_pct": 6.229371462615418,
+      "decode_pct": 4.994165694282371
+     }
+    ],
+    "frontier_logits_exact": true,
+    "frontiers_compared": 3
+   }
+  }
+ },
+ "kernel_tests": {
+  "test-kernels-2.log": "all qwen4 kernel tests passed",
+  "test-mv-exact-2.log": "all Qwen MoE decode specialization tests passed",
+  "test-q4k.log": "all qwen4 ordered Q4K geometry tests passed",
+  "test-mm-spec.log": "PASS Qwen MoE specialization type=2 T=257 mid/down exact, padding intact",
+  "test-kernels-3.log": "all qwen4 kernel tests passed",
+  "test-mm-spec-3.log": "PASS Qwen MoE specialization type=2 T=257 mid/down exact, padding intact",
+  "test-hcreuse-3.log": "all qwen4 HC norm reuse tests passed"
+ }
+}

--- a/speed-bench/qwen38-m5-round1.md
+++ b/speed-bench/qwen38-m5-round1.md
@@ -1,0 +1,177 @@
+# Qwen3.8 on Apple M5 Max, round 1: re-qualifying the M3 Ultra defaults
+
+Hardware: Apple M5 Max, 128 GB unified memory, 40-core GPU, Metal 4.
+Model: `Qwen3.8-Flash-Next-Q4KImatrixExperts-MXFP4Down-BF16Emb-BF16Control-Q8GDN-Q8QSA-Q8Shared-Q8Out-MTP.gguf`
+(the `qwen38-q4k` download) with the Q4_1 PLE sidecar. Baseline `82d0314`.
+Every accepted change keeps full-vocabulary FP32 logits byte-identical.
+
+## Why this round exists
+
+Every Qwen kernel geometry tuned so far was gated on the M3 Ultra device name,
+so an M5 ran the untuned defaults everywhere. This round measures each gated
+default on the M5 with single-engine A/B harnesses that abort on any logit
+difference, then turns the winners into M5 defaults.
+
+## Measurement discipline on this machine
+
+Two effects dominate small comparisons on the M5 Max and shaped the protocol:
+
+- **Sustained-load drift.** Four back-to-back full `ds4-bench` sweeps of the
+  same build measured 1030, 910, 870 and 850 prefill tokens/s at the same
+  frontier, and 49.7 down to 45.0 decode tokens/s. Process-level ABBA over
+  whole sweeps therefore mis-ranks a few-percent change. The lab sweep now runs
+  four fresh processes per frontier in ABBA or BAAB order, and the decode
+  harness interleaves variants per step inside one engine.
+- **First timed run.** In the prefill harness the first timed 8192-token run
+  of a process is 15-35% slower than the following ones even after a
+  2048-token warmup. With that warmup a no-op candidate "gained" +1.6% and the
+  MoE specialization "gained" +16.4%; with a full 8192-token warmup and four
+  ABBA/BAAB repeats (16 timed runs) the no-op measures +1.3% and specialization
+  +1.0%. All prefill numbers below use the full-warmup protocol unless marked
+  otherwise, and deltas under about 2% are not treated as evidence.
+
+## Baseline
+
+First cold `ds4-bench` sweep after loading (8192-token chunks, 128 greedy
+tokens): 612 to 690 prefill tokens/s and 45.4 to 48.0 decode tokens/s from 4K
+to 128K. Warm and rested, the same sweep starts at 1004 to 1046 prefill and
+49.4 to 49.8 decode tokens/s (936 / 46.3 at 128K). Short-prompt CLI plain
+decode (Hamlet, `--nothink --temp 0`): 42.7 tokens/s cold, 52.3 warm.
+
+## Tooling added
+
+- `speed-bench/qwen38_decode_variant_bench` (`make qwen38-decode-variant-bench`):
+  one engine, two sessions synced to the same prefix, every step decodes the
+  same token under both variants with alternating order and pairing, and
+  aborts unless every full-vocabulary logit row is bit-identical. Compares
+  dispatch-time environment knobs in ~35 s per run; a no-op candidate measured
+  -0.15% and -0.29%.
+- `speed-bench/metal_prefill_variant_bench` gained `--extra-env` and
+  `--control-env` so combinations can be measured against a tuned control.
+- `speed-bench/qwen38_m5_lab.py`: teacher-forced parity, per-frontier
+  interleaved ds4-bench sweeps with logit comparison, CLI plain/MTP decode
+  comparison, long-prompt MTP, and a `gate` that runs them all.
+- `speed-bench/qwen38_timeline_report.py`: per-kernel aggregation of
+  `DS4_METAL_ENCODER_TIMELINE` logs.
+- `DS4_QWEN4_GDN_PREFILL_NSG` exposes the large-prefill GDN scan grouping
+  that was hard-wired to M3 Ultra.
+
+## Where a decode token goes (encoder timeline, relative)
+
+897 dispatches per token. GPU time by kernel: dense Q8_0 projections 41%
+(138 dispatches, ~64% of peak bandwidth), Q4_K routed gate/up 14%, F16
+hyper-connection gate/mix 9%, MXFP4 routed down 8%, F16 low-rank down 7%,
+HC norm 4%, F32 router 3%, GDN front 2.4%. A standalone probe measured the
+M5 Max per-dispatch cost at ~1.2 us inside one encoder, so dispatch count is
+about 5% of the token; the rest is kernel latency and bandwidth.
+
+## Plain decode A/B (single engine, 2048-token prefix, 384 measured steps, 401 exact logit rows each)
+
+| candidate | change |
+| --- | ---: |
+| `DS4_QWEN4_Q4K_MID_NR=1 DS4_QWEN4_Q4K_MID_NSG=4` | +1.94% |
+| `... NSG=8` (M3 Ultra default) | +1.62% |
+| `... NSG=6` | +2.08% |
+| `... NSG=2` | +1.36% |
+| `NR=2 NSG=4` / `NR=2 NSG=8` | -0.40% / -0.21% |
+| `DS4_QWEN4_MOE_MV_SPECIALIZE=1` (MXFP4 down, NSG 8) | +1.30% |
+| `... DS4_QWEN4_MOE_MV_NSG=16` | +1.92% |
+| `... NSG=16 NR=2` / `NSG=12` / `NSG=4` | +1.43% / +1.04% / +1.12% |
+| Q4K NR1/NSG4 + MXFP4 specialized NSG16 | **+3.80%** |
+| Q4K NR1/NSG8 + MXFP4 specialized NSG16 | +3.65% |
+| `DS4_QWEN4_DECODE_FUSIONS=1` (both M3 Ultra decode fusions) | -0.81% |
+| Q8 QKV+gate grid concatenation alone / combine+norm fusion alone | -0.31% / -0.29% |
+| `DS4_QWEN4_GDN_NSG=2/4/8` | -0.13% / +0.10% / -0.48% |
+| `DS4_QWEN4_FLUSH_LAYER=0/1/4/8` (default 2) | -2.38% / -0.58% / -0.42% / -0.53% |
+| `DS4_QWEN4_NO_GDN_R4=1` / `DS4_QWEN4_NO_Q4K_MID=1` | -1.19% / -3.94% |
+| four-row Q8_0 matvec tile (exact per row; temporary kernel) | -0.55%, removed |
+| `DS4_METAL_Q8_MV_NSG=1/2/8` | rejected: logits differ (split-K reduction) |
+| Q8_0 decode through the Metal 4 tensor kernel | rejected: logits differ |
+
+## Prefill A/B (single engine, fresh 8192-token prefix, full warmup, 16 timed runs, 1,986,560 final logits compared per run)
+
+Control is the tree with MoE specialization on; candidates add or remove knobs.
+
+| candidate | change |
+| --- | ---: |
+| no-op | +1.3% (floor) |
+| `DS4_QWEN4_MOE_MM_SPECIALIZE=0` (rollback of specialization) | -1.0% |
+| `DS4_QWEN4_MOE_TAILS=1` | +2.3% |
+| tails + `DS4_QWEN4_MOE_MID_TILES=32` | +4.4% |
+| tails + mid tiles 32 + `DS4_QWEN4_HC_NORM_REUSE=1` | **+7.5%** |
+| the above + down tiles 32 + GDN prefill NSG 4 | +7.4% |
+
+Earlier single-knob screens with the short warmup (excluding the first timed
+run of each): mid tiles 16 / 32 +0.3% / +0.2%, down tiles 16 / 32 -0.5% /
+-0.1%, HC norm reuse +1.0%, tails +1.0%, GDN prefill NSG 2 / 4 / 8 -0.5% /
++0.4% / -0.8%, token tiles of 16 (`MOE_MID_NT=2`) -4.4%, down NT 2 -3.3%.
+Specialization at 32K (24576-token untimed prefix, 4 runs) measured within
+0.5% of generic.
+
+## Adopted M5 defaults
+
+- Single-token Q4_K gate/up decode rows: one row per SIMD group, four groups
+  per threadgroup (`DS4_QWEN4_Q4K_MID_NR` / `_NSG` override).
+- MXFP4 routed-down decode rows specialized with sixteen SIMD groups per
+  threadgroup (`DS4_QWEN4_MOE_MV_SPECIALIZE` / `_NSG` override).
+- Routed MoE prefill GEMM specialization (`DS4_QWEN4_MOE_MM_SPECIALIZE=0`
+  restores generic kernels), remainder tiles for Q4_K gate/up and MXFP4 down
+  (`DS4_QWEN4_MOE_TAILS=0`), gate/up tile caps of 16 from 4096 tokens and 32
+  from 8192 (`DS4_QWEN4_MOE_MID_TILES`), and hyper-connection RMS reuse from
+  8192 tokens (`DS4_QWEN4_HC_NORM_REUSE=0`).
+
+The M3 Ultra ordinary-decode fusions stay off on M5.
+
+## Lab gate
+
+Decode defaults (`96dd6bf`) against the baseline:
+
+- Teacher-forced parity: exact on 6 histories x 32 full-vocabulary rows.
+- ds4-bench frontier logits at 4K, 8K, 16K, 32K, 64K and 128K: exact across
+  every run of both builds.
+- CLI greedy decode, three prompts, three interleaved repeats each, medians:
+
+| prompt | plain baseline | plain candidate | change | MTP baseline | MTP candidate | change |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Hamlet | 52.27 | 54.67 | +4.59% | 63.93 | 65.65 | +2.69% |
+| Fibonacci | 52.23 | 54.50 | +4.35% | 77.42 | 79.55 | +2.75% |
+| Explanation | 52.30 | 54.80 | +4.78% | 68.62 | 70.42 | +2.62% |
+
+All outputs and MTP acceptance counters matched.
+
+- Per-frontier interleaved sweep (four fresh processes per frontier, 128
+  greedy tokens), decode defaults plus MoE specialization:
+
+| ctx | prefill baseline | prefill candidate | change | decode baseline | decode candidate | change |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 32,768 | 906.6 | 938.4 | +3.51% | 46.18 | 47.49 | +2.84% |
+| 131,072 | 864.1 | 868.1 | +0.47% | 42.97 | 44.38 | +3.31% |
+
+Frontier logits exact across all four runs at both frontiers.
+
+Prefill defaults (this tree) against their own rollback, single engine, full
+warmup, 16 timed runs each, all final logits exact:
+
+| candidate (rollback) | change |
+| --- | ---: |
+| 8192-token chunks: tails off, gate/up tile cap 8, HC RMS reuse off | -5.1% |
+| 4096-token chunks: tails off | -4.1% |
+| 4096-token chunks: gate/up tile cap 8 instead of 16 | -0.7% |
+
+Per-frontier interleaved sweep, all M5 defaults against the baseline, fans at
+maximum and no other model loaded:
+
+| ctx | prefill baseline | prefill candidate | change | decode baseline | decode candidate | change |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 4,096 | 1036.4 | 1168.0 | +12.70% | 49.70 | 52.16 | +4.93% |
+| 32,768 | 946.2 | 1046.7 | +10.63% | 47.71 | 50.09 | +4.99% |
+| 131,072 | 839.2 | 891.5 | +6.23% | 42.85 | 44.99 | +4.99% |
+
+Frontier logits exact across all four runs at every frontier.
+
+## Validation
+
+`make test-qwen4-kernels`, `DS4_TEST_QWEN4_MV_EXACT=1` (extended to Q4_K
+gate/up beside MXFP4 down), `DS4_TEST_QWEN4_Q4K_ORDERED_ONLY=1`,
+`DS4_TEST_QWEN4_HC_NORM_REUSE_ONLY=1` and `make test-qwen4-moe-mm-specialize`
+pass on the M5. Raw records are in `qwen38-m5-round1-results.json`.

--- a/speed-bench/qwen38-m5-round2.md
+++ b/speed-bench/qwen38-m5-round2.md
@@ -1,0 +1,113 @@
+# Qwen3.8 on Apple M5 Max, round 2: kernel geometry, tile order, MTP rollback
+
+Hardware, model and rules as in [round 1](qwen38-m5-round1.md). Baseline for
+this round: `1bc6e6d` (round-1 defaults). Every accepted change keeps
+full-vocabulary FP32 logits byte-identical; every A/B below compared every
+logit row (decode) or the final logits of every run or repeat (prefill).
+
+## Decode (single engine, per-step interleaved, 2048-token prefix unless noted)
+
+| change | measurement | result |
+| --- | --- | ---: |
+| F16/F32 matvecs one row per SIMD group (hc low-rank down, router) | rollback to two rows, two runs | -0.55% / -0.54% |
+| GDN front threadgroup 1024 threads (was 256) | 512 / 1024 | +0.14% / +0.69% |
+| MoE reduce threadgroup 64 / 128 threads | env | +0.05% / -0.02% (dropped) |
+| HC combine threadgroup 64 / 128 threads | env | -0.05% / -0.07% (dropped) |
+| shared expert slot dispatched first in the MoE grids | two runs | +0.10% / +0.08% (dropped) |
+| attention layer q + k/v/indexer projections in one dispatch | two runs | +0.06% / +0.08% (dropped) |
+| four-row Q8_0 matvec tile | env | -0.55% (dropped) |
+| F16 HC gate/mix with eight terms loaded ahead per lane | env | rejected: logits differ (fast-math contraction changed with the staged loop) |
+| vector indexer scorer with staged queries, 64K prefix | rollback | -0.80% |
+| one-thread-per-dim split-attention merge, 64K prefix | rollback | +0.04% (kept: exact, no cost) |
+| scorer + merge together, 64K / 2K prefix | rollback | -1.85% / -1.03% |
+| merge loading sixteen splits ahead of its chain, 64K prefix | rollback | -0.80% |
+| tile-max prefiltered top-k, 64K prefix (16K blocks) | rollback, two runs | -0.01% / -0.82% |
+| no-op candidate, 2K / 64K prefix | env | -0.005% / +0.16% |
+
+## MTP
+
+Zero-copy rejection rollback (swap the live and snapshot state buffers instead
+of 73 blits): CLI compare, three prompts, three interleaved repeats, identical
+outputs and acceptance counters. Hamlet 65.81 -> 66.39 t/s, explanation
+70.55 -> 71.07 t/s (rejection-heavy); Fibonacci within noise.
+
+## Prefill
+
+Expert-major tile order (`DS4_QWEN4_MOE_MM_ORDER`): +1.8% and +2.1% at
+8192-token chunks (16 fresh-session runs each), +0.8% at 4096-token chunks,
++2.6% over the drift-free second pass of a chunk-interleaved 64K prefill.
+The interleaved mode exposed the first-session penalty (every chunk after the
+first of the first session at a new context length runs ~25% slower) and
+the harness now walks an untimed pass first.
+
+The prefiltered top-k is proven exact by a fixture (rows up to 65536 blocks,
+ties at both ends, full and prefiltered selections compared byte for byte)
+and targets 128K-262K contexts, where the full-row radix select reads its
+256 KB row six times per layer.
+
+## Where the long-context decode time goes (encoder timeline at a 128K prefix, relative)
+
+911 dispatches per token. Indexer scoring 3.1%, radix top-k 2.4%, gathered
+attention 1.8%, split merge 1.7%, attention prep 0.8% per token, against a
+2K prompt where the whole attention family is under 2%. The prefiltered
+top-k (next section of work) targets the radix select.
+
+## Adopted M5 defaults this round
+
+- Single-token F16/F32 matvecs with at most 1024 rows launch one row per
+  SIMD group (`DS4_METAL_PLAIN_MV_NR0`).
+- GDN front threadgroups of 1024 threads (`DS4_QWEN4_GDN_FRONT_THREADS`).
+- Expert-major prefill tile order (`DS4_QWEN4_MOE_MM_ORDER`).
+- Vector indexer scorer and one-thread-per-dim split merge
+  (`DS4_QWEN4_IDX_SCORE_VEC`, `DS4_QWEN4_ATTN_MERGE_WIDE`).
+- Prefiltered decode top-k (`DS4_QWEN4_IDX_PREFILTER`).
+- MTP rejection rollback by buffer swap on every device
+  (`DS4_QWEN4_MTP_SWAP_RESTORE=0` restores the copy).
+
+## To measure on M3 Ultra
+
+Everything above except the MTP rollback is gated on M5. The mechanisms
+that do not depend on the M5's core count are worth a 35-second A/B each
+with the decode harness (both variants share one engine, every logit row
+compared):
+
+```sh
+make qwen38-decode-variant-bench
+B="./speed-bench/qwen38_decode_variant_bench -m MODEL --ple PLE --prompt-file speed-bench/promessi_sposi.txt"
+$B --candidate-env DS4_METAL_PLAIN_MV_NR0=1        # one-row F16/F32 matvecs
+$B --candidate-env DS4_QWEN4_GDN_FRONT_THREADS=1024
+$B --candidate-env DS4_QWEN4_IDX_SCORE_VEC=1 --candidate-env DS4_QWEN4_ATTN_MERGE_WIDE=1 --prefix-tokens 65536
+$B --candidate-env DS4_QWEN4_IDX_PREFILTER=1 --candidate-env DS4_QWEN4_IDX_SCORE_VEC=1 --prefix-tokens 131072
+./speed-bench/metal_prefill_variant_bench -m MODEL --ple PLE --prompt-file speed-bench/promessi_sposi.txt \
+  --interleave --prefix-tokens 65536 --prefill-chunk 8192 --warmup-tokens 8192 --repeats 2 \
+  --candidate-env DS4_QWEN4_MOE_MM_ORDER --candidate-value 1
+```
+
+The single-token Q4_K NSG 4 and MXFP4 NSG 16 geometries are M5-specific;
+M3 Ultra keeps its measured NR1/NSG8 and low-bit defaults.
+
+## Lab gate
+
+Against the round-1 baseline `82d0314` (round-1 and round-2 defaults
+together), teacher-forced parity exact on 6 histories x 32 rows; CLI greedy
+decode, three prompts, three interleaved repeats each, medians, all outputs
+and acceptance counters identical:
+
+| prompt | plain baseline | plain candidate | change | MTP baseline | MTP candidate | change |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Hamlet | 52.15 | 55.12 | +5.70% | 64.05 | 66.67 | +4.09% |
+| Fibonacci | 52.23 | 55.24 | +5.76% | 77.65 | 80.11 | +3.17% |
+| Explanation | 52.37 | 55.34 | +5.67% | 68.73 | 71.36 | +3.83% |
+
+Per-frontier interleaved sweep (four fresh processes per frontier, 128 greedy
+tokens), all round-1 and round-2 defaults against the baseline, frontier
+logits exact across every run:
+
+| ctx | prefill baseline | prefill candidate | change | decode baseline | decode candidate | change |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 4,096 | 1027.9 | 1122.1 | +9.17% | 46.41 | 49.03 | +5.67% |
+| 32,768 | 887.2 | 983.3 | +10.83% | 44.29 | 47.37 | +6.95% |
+| 131,072 | 834.7 | 908.8 | +8.88% | 41.84 | 45.53 | +8.82% |
+
+The 128K decode gain over round 1 (+5.0% then) is the long-context work:
+vector scorer, prefetched split merge and prefiltered top-k.

--- a/speed-bench/qwen38_decode_variant_bench.c
+++ b/speed-bench/qwen38_decode_variant_bench.c
@@ -1,0 +1,383 @@
+#include "ds4.h"
+
+#include <errno.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+/* Balanced same-engine Qwen decode A/B for dispatch-time environment knobs.
+ *
+ * One engine, two sessions synced to the same prefix.  Every step decodes the
+ * same token in both sessions, once per variant, alternating both the variant
+ * order and the variant-to-session pairing, and aborts unless every
+ * full-vocabulary logit row is bit-identical.  Model load and prefill are
+ * outside the timers, so a 512-step comparison costs seconds instead of the
+ * minutes a process-per-variant CLI comparison needs, and both variants see
+ * the same thermal and memory state.  Only knobs read at dispatch time can be
+ * compared: settings cached when the graph is allocated look identical here.
+ */
+
+enum {
+    VARIANT_COUNT = 2,
+    MAX_ENV = 16,
+    DEFAULT_PREFIX_TOKENS = 2048,
+    DEFAULT_WARMUP = 16,
+    DEFAULT_MEASURED = 512,
+};
+
+typedef struct {
+    char *name;
+    char *value;   /* NULL: unset for this variant */
+} env_setting;
+
+typedef struct {
+    env_setting items[MAX_ENV];
+    int n;
+} env_list;
+
+typedef struct {
+    const char *model_path;
+    const char *ple_path;
+    const char *prompt_path;
+    int prefix_tokens;
+    int ctx;
+    int warmup;
+    int measured;
+    uint32_t prefill_chunk;
+    env_list variant[VARIANT_COUNT];   /* 0 = control, 1 = candidate */
+} bench_config;
+
+static void usage(FILE *fp, const char *argv0) {
+    fprintf(fp,
+            "usage: %s --candidate-env NAME[=VALUE] [options]\n"
+            "\n"
+            "  -m, --model PATH          GGUF path (default: ds4flash.gguf)\n"
+            "  --ple PATH                optional PLE sidecar\n"
+            "  --prompt-file PATH        token source (default: ds4.c)\n"
+            "  --candidate-env NAME[=V]  set NAME (default value 1) for the candidate,\n"
+            "                            unset it for the control; repeatable\n"
+            "  --control-env NAME=V      set NAME=V for the control instead of unsetting\n"
+            "  --prefix-tokens N         prefill length (default: 2048)\n"
+            "  --prefill-chunk N         prefill chunk size (default: engine default)\n"
+            "  --ctx N                   session allocation (default: prefix + steps + 1)\n"
+            "  --warmup N                untimed steps per variant (default: 16)\n"
+            "  --tokens N                measured steps per variant (default: 512)\n",
+            argv0);
+}
+
+static const char *need_arg(int *i, int argc, char **argv, const char *opt) {
+    if (*i + 1 >= argc) {
+        fprintf(stderr, "qwen38-decode-variant-bench: %s requires an argument\n", opt);
+        exit(2);
+    }
+    return argv[++*i];
+}
+
+static int parse_int_arg(const char *value, const char *opt, int minimum) {
+    char *end = NULL;
+    errno = 0;
+    long parsed = strtol(value, &end, 10);
+    if (errno != 0 || value[0] == '\0' || !end || *end != '\0' ||
+        parsed < minimum || parsed > INT_MAX) {
+        fprintf(stderr, "qwen38-decode-variant-bench: invalid value for %s: %s\n", opt, value);
+        exit(2);
+    }
+    return (int)parsed;
+}
+
+static void env_list_add(env_list *list, const char *spec, bool require_value, const char *opt) {
+    if (list->n >= MAX_ENV) {
+        fprintf(stderr, "qwen38-decode-variant-bench: too many %s settings\n", opt);
+        exit(2);
+    }
+    const char *eq = strchr(spec, '=');
+    if (spec[0] == '\0' || spec[0] == '=' || (require_value && !eq)) {
+        fprintf(stderr, "qwen38-decode-variant-bench: %s needs NAME%s: %s\n",
+                opt, require_value ? "=VALUE" : "[=VALUE]", spec);
+        exit(2);
+    }
+    env_setting *e = &list->items[list->n++];
+    const size_t name_len = eq ? (size_t)(eq - spec) : strlen(spec);
+    const char *value = eq ? eq + 1 : "1";
+    e->name = malloc(name_len + 1u);
+    e->value = malloc(strlen(value) + 1u);
+    if (!e->name || !e->value) {
+        fprintf(stderr, "qwen38-decode-variant-bench: out of memory\n");
+        exit(1);
+    }
+    memcpy(e->name, spec, name_len);
+    e->name[name_len] = '\0';
+    strcpy(e->value, value);
+}
+
+static bench_config parse_options(int argc, char **argv) {
+    bench_config cfg = {
+        .model_path = "ds4flash.gguf",
+        .prompt_path = "ds4.c",
+        .prefix_tokens = DEFAULT_PREFIX_TOKENS,
+        .warmup = DEFAULT_WARMUP,
+        .measured = DEFAULT_MEASURED,
+    };
+    for (int i = 1; i < argc; i++) {
+        const char *arg = argv[i];
+        if (!strcmp(arg, "-h") || !strcmp(arg, "--help")) {
+            usage(stdout, argv[0]);
+            exit(0);
+        } else if (!strcmp(arg, "-m") || !strcmp(arg, "--model")) {
+            cfg.model_path = need_arg(&i, argc, argv, arg);
+        } else if (!strcmp(arg, "--ple")) {
+            cfg.ple_path = need_arg(&i, argc, argv, arg);
+        } else if (!strcmp(arg, "--prompt-file")) {
+            cfg.prompt_path = need_arg(&i, argc, argv, arg);
+        } else if (!strcmp(arg, "--candidate-env")) {
+            env_list_add(&cfg.variant[1], need_arg(&i, argc, argv, arg), false, arg);
+        } else if (!strcmp(arg, "--control-env")) {
+            env_list_add(&cfg.variant[0], need_arg(&i, argc, argv, arg), true, arg);
+        } else if (!strcmp(arg, "--prefix-tokens")) {
+            cfg.prefix_tokens = parse_int_arg(need_arg(&i, argc, argv, arg), arg, 1);
+        } else if (!strcmp(arg, "--prefill-chunk")) {
+            cfg.prefill_chunk = (uint32_t)parse_int_arg(need_arg(&i, argc, argv, arg), arg, 1);
+        } else if (!strcmp(arg, "--ctx")) {
+            cfg.ctx = parse_int_arg(need_arg(&i, argc, argv, arg), arg, 1);
+        } else if (!strcmp(arg, "--warmup")) {
+            cfg.warmup = parse_int_arg(need_arg(&i, argc, argv, arg), arg, 0);
+        } else if (!strcmp(arg, "--tokens") || !strcmp(arg, "--measured")) {
+            cfg.measured = parse_int_arg(need_arg(&i, argc, argv, arg), arg, 1);
+        } else {
+            fprintf(stderr, "qwen38-decode-variant-bench: unknown option: %s\n", arg);
+            usage(stderr, argv[0]);
+            exit(2);
+        }
+    }
+    if (cfg.variant[1].n == 0) {
+        fprintf(stderr, "qwen38-decode-variant-bench: --candidate-env is required\n");
+        exit(2);
+    }
+    const int64_t needed = (int64_t)cfg.prefix_tokens + cfg.warmup + cfg.measured + 1;
+    if (cfg.ctx == 0) cfg.ctx = (int)needed;
+    if (needed > cfg.ctx) {
+        fprintf(stderr,
+                "qwen38-decode-variant-bench: --ctx must exceed prefix + warmup + measured (minimum %lld)\n",
+                (long long)needed);
+        exit(2);
+    }
+    return cfg;
+}
+
+static double now_sec(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec + (double)ts.tv_nsec / 1.0e9;
+}
+
+static char *read_text(const char *path) {
+    FILE *fp = fopen(path, "rb");
+    if (!fp) {
+        fprintf(stderr, "qwen38-decode-variant-bench: failed to open %s: %s\n", path, strerror(errno));
+        return NULL;
+    }
+    if (fseek(fp, 0, SEEK_END) != 0) { fclose(fp); return NULL; }
+    long len = ftell(fp);
+    if (len < 0 || fseek(fp, 0, SEEK_SET) != 0) { fclose(fp); return NULL; }
+    char *text = malloc((size_t)len + 1u);
+    if (!text || fread(text, 1, (size_t)len, fp) != (size_t)len) {
+        fprintf(stderr, "qwen38-decode-variant-bench: failed to read %s\n", path);
+        free(text);
+        fclose(fp);
+        return NULL;
+    }
+    text[len] = '\0';
+    fclose(fp);
+    return text;
+}
+
+/* Apply one variant: its own settings are set, the other variant's names are
+ * unset unless this variant also names them. */
+static int select_variant(const bench_config *cfg, int variant) {
+    const env_list *mine = &cfg->variant[variant];
+    const env_list *other = &cfg->variant[variant ^ 1];
+    for (int i = 0; i < other->n; i++) {
+        bool covered = false;
+        for (int j = 0; j < mine->n; j++) covered |= strcmp(mine->items[j].name, other->items[i].name) == 0;
+        if (!covered && unsetenv(other->items[i].name) != 0) {
+            fprintf(stderr, "qwen38-decode-variant-bench: unsetenv %s failed\n", other->items[i].name);
+            return 1;
+        }
+    }
+    for (int i = 0; i < mine->n; i++) {
+        if (setenv(mine->items[i].name, mine->items[i].value, 1) != 0) {
+            fprintf(stderr, "qwen38-decode-variant-bench: setenv %s failed\n", mine->items[i].name);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static uint32_t float_bits(float value) {
+    uint32_t bits = 0;
+    memcpy(&bits, &value, sizeof(bits));
+    return bits;
+}
+
+static int compare_frontier(ds4_session *s0, ds4_session *s1, float *l0, float *l1,
+                            int vocab, int eos, size_t step, int *token_out) {
+    const size_t row_bytes = (size_t)vocab * sizeof(l0[0]);
+    if (ds4_session_pos(s0) != ds4_session_pos(s1)) {
+        fprintf(stderr, "qwen38-decode-variant-bench: position mismatch at step %zu\n", step);
+        return 1;
+    }
+    memset(l0, 0xa5, row_bytes);
+    memset(l1, 0x5a, row_bytes);
+    if (ds4_session_copy_logits(s0, l0, vocab) != vocab ||
+        ds4_session_copy_logits(s1, l1, vocab) != vocab) {
+        fprintf(stderr, "qwen38-decode-variant-bench: failed to copy logits at step %zu\n", step);
+        return 1;
+    }
+    if (memcmp(l0, l1, row_bytes) != 0) {
+        size_t first = SIZE_MAX, differing = 0;
+        for (int i = 0; i < vocab; i++) {
+            if (memcmp(&l0[i], &l1[i], sizeof(float)) != 0) {
+                if (first == SIZE_MAX) first = (size_t)i;
+                differing++;
+            }
+        }
+        fprintf(stderr,
+                "qwen38-decode-variant-bench: raw logit mismatch at step %zu: differing=%zu/%d "
+                "top0=%d top1=%d first id=%zu control=%a (0x%08x) candidate=%a (0x%08x)\n",
+                step, differing, vocab, ds4_session_argmax(s0), ds4_session_argmax(s1),
+                first, l0[first], (unsigned)float_bits(l0[first]),
+                l1[first], (unsigned)float_bits(l1[first]));
+        return 1;
+    }
+    const int t0 = ds4_session_argmax_excluding(s0, eos);
+    const int t1 = ds4_session_argmax_excluding(s1, eos);
+    if (t0 < 0 || t0 != t1) {
+        fprintf(stderr, "qwen38-decode-variant-bench: token mismatch at step %zu: %d vs %d\n", step, t0, t1);
+        return 1;
+    }
+    if (token_out) *token_out = t0;
+    return 0;
+}
+
+static void print_env_list(FILE *fp, const env_list *list, const char *label) {
+    fprintf(fp, "%s=", label);
+    if (list->n == 0) fputs("(unset)", fp);
+    for (int i = 0; i < list->n; i++)
+        fprintf(fp, "%s%s=%s", i ? "," : "", list->items[i].name, list->items[i].value);
+}
+
+int main(int argc, char **argv) {
+    const bench_config cfg = parse_options(argc, argv);
+    char *text = read_text(cfg.prompt_path);
+    if (!text) return 1;
+    if (select_variant(&cfg, 0) != 0) { free(text); return 1; }
+
+    ds4_engine_options opt = {
+        .model_path = cfg.model_path,
+        .ple_path = cfg.ple_path,
+        .backend = DS4_BACKEND_METAL,
+        .context_size = cfg.ctx,
+        .prefill_chunk = cfg.prefill_chunk,
+        .power_percent = 100,
+        .warm_weights = true,
+    };
+    ds4_engine *engine = NULL;
+    ds4_session *sessions[VARIANT_COUNT] = {0};
+    ds4_tokens tokens = {0};
+    float *logits[VARIANT_COUNT] = {0};
+    char err[256] = {0};
+    double elapsed[VARIANT_COUNT] = {0};
+    size_t measured_tokens[VARIANT_COUNT] = {0};
+    size_t exact_rows = 0;
+    int rc = 1;
+
+    if (ds4_engine_open(&engine, &opt) != 0) goto done;
+    ds4_tokenize_text(engine, text, &tokens);
+    free(text);
+    text = NULL;
+    if (tokens.len < cfg.prefix_tokens) {
+        fprintf(stderr, "qwen38-decode-variant-bench: prompt has %d tokens; need %d\n",
+                tokens.len, cfg.prefix_tokens);
+        goto done;
+    }
+    const int vocab = ds4_engine_vocab_size(engine);
+    ds4_tokens prefix = { .v = tokens.v, .len = cfg.prefix_tokens, .cap = cfg.prefix_tokens };
+    for (int i = 0; i < VARIANT_COUNT; i++) {
+        /* Both prefixes run under the control settings so the compared decode
+         * steps start from identical state. */
+        if (ds4_session_create(&sessions[i], engine, cfg.ctx) != 0 ||
+            ds4_session_sync(sessions[i], &prefix, err, sizeof(err)) != 0) {
+            fprintf(stderr, "qwen38-decode-variant-bench: session %d prefill failed: %s\n",
+                    i, err[0] ? err : "unknown error");
+            goto done;
+        }
+        logits[i] = malloc((size_t)vocab * sizeof(float));
+        if (!logits[i]) goto done;
+    }
+
+    fprintf(stderr, "qwen38-decode-variant-bench: model=%s prefix=%d ctx=%d warmup=%d measured=%d ",
+            cfg.model_path, cfg.prefix_tokens, cfg.ctx, cfg.warmup, cfg.measured);
+    print_env_list(stderr, &cfg.variant[0], "control");
+    fputc(' ', stderr);
+    print_env_list(stderr, &cfg.variant[1], "candidate");
+    fputc('\n', stderr);
+
+    const int eos = ds4_token_eos(engine);
+    const int total_steps = cfg.warmup + cfg.measured;
+    for (int step = 0; step < total_steps; step++) {
+        int token = -1;
+        if (compare_frontier(sessions[0], sessions[1], logits[0], logits[1], vocab, eos,
+                             (size_t)step, &token) != 0) goto done;
+        exact_rows++;
+        /* Even steps: control on session 0 then candidate on session 1.  Odd
+         * steps reverse both the pairing and the order. */
+        for (int order = 0; order < VARIANT_COUNT; order++) {
+            const int session_i = order;
+            const int variant_i = (order + step) & 1;
+            if (select_variant(&cfg, variant_i) != 0) goto done;
+            const double t0 = now_sec();
+            if (ds4_session_eval(sessions[session_i], token, err, sizeof(err)) != 0) {
+                fprintf(stderr, "qwen38-decode-variant-bench: decode failed at step=%d variant=%s: %s\n",
+                        step, variant_i ? "candidate" : "control", err[0] ? err : "unknown error");
+                goto done;
+            }
+            const int selected = ds4_session_argmax_excluding(sessions[session_i], eos);
+            const double t1 = now_sec();
+            if (selected < 0) goto done;
+            if (step >= cfg.warmup) {
+                elapsed[variant_i] += t1 - t0;
+                measured_tokens[variant_i]++;
+            }
+        }
+    }
+    if (compare_frontier(sessions[0], sessions[1], logits[0], logits[1], vocab, eos,
+                         (size_t)total_steps, NULL) != 0) goto done;
+    exact_rows++;
+
+    for (int v = 0; v < VARIANT_COUNT; v++) {
+        printf("variant=%s tokens=%zu seconds=%.6f tokens_per_second=%.4f\n",
+               v ? "candidate" : "control", measured_tokens[v], elapsed[v],
+               elapsed[v] > 0.0 ? (double)measured_tokens[v] / elapsed[v] : 0.0);
+    }
+    if (elapsed[1] > 0.0 && measured_tokens[1] && measured_tokens[0]) {
+        const double c = (double)measured_tokens[0] / elapsed[0];
+        const double k = (double)measured_tokens[1] / elapsed[1];
+        printf("speedup=%.4f percent=%+.3f exact_rows=%zu exact_floats=%zu\n",
+               k / c, (k / c - 1.0) * 100.0, exact_rows, exact_rows * (size_t)vocab);
+    }
+    rc = 0;
+
+done:
+    for (int i = 0; i < VARIANT_COUNT; i++) {
+        free(logits[i]);
+        if (sessions[i]) ds4_session_free(sessions[i]);
+    }
+    ds4_tokens_free(&tokens);
+    if (engine) ds4_engine_close(engine);
+    free(text);
+    return rc;
+}

--- a/speed-bench/qwen38_m5_lab.py
+++ b/speed-bench/qwen38_m5_lab.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""Qwen3.8 Metal optimization lab: exactness gate plus prefill/decode measurement.
+
+Compares a frozen baseline build (a separate worktree with its own binaries and
+metal/ sources) against the working tree.  Every measurement is interleaved
+and every accepted change must keep full-vocabulary FP32 logits byte-identical.
+
+Subcommands:
+  parity     teacher-forced full-logit parity (1..128 prompt tokens, 32 rows each)
+  sweep      ds4-bench prefill+greedy-decode sweep for both builds, both orders,
+             with per-frontier logit dumps compared byte for byte
+  decode     short-prompt plain decode and MTP decode (qwen38_mtp_compare.py)
+  mtp-long   MTP decode on long raw prompts (32K/128K), both builds interleaved
+  prefill-ab single-engine env A/B (metal_prefill_variant_bench)
+  decode-ab  single-engine env A/B (qwen38_decode_variant_bench)
+  gate       parity + decode + sweep, then a summary JSON and Markdown
+
+Raw artifacts go under --out (default: OUT/qwen38-m5-lab/<name>, ignored by
+git); commit only the summary files.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import statistics
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_BASE = ROOT.parent / "ds4-baseline"
+DEFAULT_MODEL = ROOT / "gguf" / ("Qwen3.8-Flash-Next-Q4KImatrixExperts-MXFP4Down-BF16Emb-BF16Control-"
+                                 "Q8GDN-Q8QSA-Q8Shared-Q8Out-MTP.gguf")
+DEFAULT_PLE = ROOT / "gguf" / "Qwen3.8-Flash-Next-PLE-Q4_1.gguf"
+DEFAULT_PROMPT = ROOT / "speed-bench" / "promessi_sposi.txt"
+RATE = re.compile(r"ds4: (?:Qwen3\.8 )?prefill: ([\d.]+) t/s, generation: ([\d.]+) t/s")
+ACCEPT = re.compile(r"ds4: Qwen3\.8 mtp: (\d+) verify cycles, (\d+) drafts accepted")
+
+
+def sha256(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 22), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def clean_env(extra=None):
+    env = {k: v for k, v in os.environ.items() if not k.startswith("DS4_")}
+    if extra:
+        env.update(extra)
+    return env
+
+
+def git_head(path):
+    try:
+        return subprocess.run(["git", "-C", str(path), "rev-parse", "--short", "HEAD"],
+                              capture_output=True, text=True, check=True).stdout.strip()
+    except Exception:
+        return "?"
+
+
+class Lab:
+    def __init__(self, args):
+        self.args = args
+        self.base = Path(args.base).resolve()
+        self.cand = ROOT
+        self.model = Path(args.model).resolve()
+        self.ple = Path(args.ple).resolve()
+        self.prompt = Path(args.prompt).resolve()
+        self.out = Path(args.out).resolve() if args.out else ROOT / "OUT" / "qwen38-m5-lab" / args.name
+        self.out.mkdir(parents=True, exist_ok=True)
+        self.builds = {"baseline": self.base, "candidate": self.cand}
+        self.log = (self.out / "lab.log").open("a")
+        self.report = {
+            "name": args.name, "started_utc": datetime.now(timezone.utc).isoformat(),
+            "model": str(self.model), "ple": str(self.ple), "prompt": str(self.prompt),
+            "builds": {name: {"dir": str(d), "head": git_head(d),
+                              "ds4_sha256": sha256(d / "ds4") if (d / "ds4").exists() else None,
+                              "ds4_bench_sha256": sha256(d / "ds4-bench") if (d / "ds4-bench").exists() else None,
+                              "metal_sha256": {p.name: sha256(p) for p in sorted((d / "metal").glob("*.metal"))}}
+                       for name, d in self.builds.items()},
+            "candidate_env": dict(kv.split("=", 1) for kv in args.candidate_env),
+            "steps": {},
+        }
+        differing = [n for n in self.report["builds"]["baseline"]["metal_sha256"]
+                     if self.report["builds"]["baseline"]["metal_sha256"][n] !=
+                     self.report["builds"]["candidate"]["metal_sha256"].get(n)]
+        self.report["metal_sources_differing"] = differing
+        self.say(f"lab {args.name}: baseline {self.report['builds']['baseline']['head']} vs candidate "
+                 f"{self.report['builds']['candidate']['head']}; differing metal sources: {differing or 'none'}")
+
+    def say(self, msg):
+        line = f"[{datetime.now().strftime('%H:%M:%S')}] {msg}"
+        print(line, flush=True)
+        self.log.write(line + "\n")
+        self.log.flush()
+
+    def save(self):
+        (self.out / "results.json").write_text(json.dumps(self.report, indent=2) + "\n")
+
+    def env_for(self, build):
+        return clean_env(self.report["candidate_env"] if build == "candidate" else None)
+
+    def run(self, build, cmd, stem, cwd=None, env=None):
+        """Run cmd from the build directory so that build's metal/ sources load."""
+        cwd = cwd or self.builds[build]
+        stem = Path(stem)
+        t0 = time.monotonic()
+        with stem.with_suffix(".stdout").open("wb") as out, stem.with_suffix(".stderr").open("wb") as err:
+            rc = subprocess.run(cmd, cwd=cwd, env=env or self.env_for(build), stdout=out, stderr=err).returncode
+        wall = time.monotonic() - t0
+        if rc != 0:
+            tail = stem.with_suffix(".stderr").read_text()[-2000:]
+            raise RuntimeError(f"{' '.join(map(str, cmd))} failed rc={rc} in {wall:.1f}s:\n{tail}")
+        return wall
+
+    # ---------------------------------------------------------------- parity
+    def parity(self):
+        """Teacher-forced full-logit dumps through the production Metal graph."""
+        d = self.out / "parity"
+        d.mkdir(exist_ok=True)
+        text = [814, 20139, 1204, 264, 6165, 20653, 264, 3370, 1622, 888,
+                25804, 321, 20539, 279, 1965, 13]
+        sizes = [1, 2, 8, 9, 39, 128]
+        rec = {"sizes": sizes, "checks": []}
+        for build, bdir in self.builds.items():
+            listing = d / f"{build}.tsv"
+            listing.write_text("".join(
+                ",".join(map(str, (text * 8)[:n])) + "|" + ",".join(map(str, text * 2)) +
+                "\t" + str((d / f"{build}-{n}.f32").resolve()) + "\n" for n in sizes))
+            env = self.env_for(build)
+            env.update({"DS4_QWEN4_FT_LIST": str(listing), "DS4_QWEN4_GPU": "1"})
+            cmd = [str(bdir / "ds4"), "-m", str(self.model), "--ple", str(self.ple), "--metal",
+                   "-c", "32768", "--nothink", "--temp", "0", "--first-token-test", "--raw", "-p", "x"]
+            wall = self.run(build, cmd, d / f"{build}-ft", env=env)
+            self.say(f"parity {build}: {wall:.1f}s")
+        ok = True
+        for n in sizes:
+            paths = [d / f"{b}-{n}.f32" for b in self.builds]
+            hashes = [sha256(p) for p in paths]
+            same = hashes[0] == hashes[1] and paths[0].stat().st_size == paths[1].stat().st_size > 0
+            ok &= same
+            rec["checks"].append({"prompt_tokens": n, "rows": 32, "bytes": paths[0].stat().st_size,
+                                  "exact": same, "sha256": hashes})
+            self.say(f"parity n={n}: {'EXACT' if same else 'MISMATCH'}")
+        rec["exact"] = ok
+        self.report["steps"]["parity"] = rec
+        self.save()
+        return ok
+
+    # ----------------------------------------------------------------- sweep
+    def sweep_one(self, build, tag, ctx_max):
+        d = self.out / "sweep" / f"{tag}-{build}"
+        (d / "logits").mkdir(parents=True, exist_ok=True)
+        gen = self.args.gen_tokens
+        cmd = [str(self.builds[build] / "ds4-bench"), "-m", str(self.model), "--ple", str(self.ple), "--metal",
+               "--prompt-file", str(self.prompt), "--ctx-start", str(self.args.ctx_start),
+               "--ctx-max", str(ctx_max), "--step-mul", "2", "--gen-tokens", str(gen),
+               "--csv", str(d / "speed.csv"), "--dump-frontier-logits-dir", str(d / "logits")]
+        env = self.env_for(build)
+        env["DS4_BENCH_FORCE_SNAPSHOT"] = "1"
+        wall = self.run(build, cmd, d / "bench", env=env)
+        rows = []
+        for line in (d / "speed.csv").read_text().splitlines()[1:]:
+            f = line.split(",")
+            rows.append({"ctx": int(f[0]), "prefill_tokens": int(f[1]), "prefill_tps": float(f[2]),
+                         "gen_tps": float(f[4]), "gen_first_ms": float(f[5]), "gen_steady_tps": float(f[7])})
+        logits = {p.name: sha256(p) for p in sorted((d / "logits").glob("frontier_*.logits.json"))}
+        self.say(f"sweep {tag} {build}: {wall:.0f}s " +
+                 " ".join(f"{r['ctx']}:{r['prefill_tps']:.0f}/{r['gen_tps']:.2f}" for r in rows))
+        return {"rows": rows, "logits_sha256": logits, "wall_s": wall}
+
+    def sweep(self):
+        ctx_max = self.args.ctx_max
+        runs = {}
+        order = [["baseline", "candidate"], ["candidate", "baseline"]][: self.args.sweep_orders]
+        for i, pair in enumerate(order):
+            for build in pair:
+                runs[f"r{i}-{build}"] = self.sweep_one(build, f"r{i}", ctx_max)
+        # exactness: every frontier dump must match across all runs
+        names = sorted({n for r in runs.values() for n in r["logits_sha256"]})
+        exact = all(len({r["logits_sha256"].get(n) for r in runs.values()}) == 1 for n in names)
+        # per-context means
+        ctxs = sorted({row["ctx"] for r in runs.values() for row in r["rows"]})
+        table = []
+        for ctx in ctxs:
+            entry = {"ctx": ctx}
+            for build in self.builds:
+                vals = [row for k, r in runs.items() if k.endswith(build) for row in r["rows"] if row["ctx"] == ctx]
+                entry[build] = {"prefill_tps": statistics.mean(v["prefill_tps"] for v in vals),
+                                "gen_tps": statistics.mean(v["gen_tps"] for v in vals),
+                                "gen_steady_tps": statistics.mean(v["gen_steady_tps"] for v in vals)}
+            entry["prefill_pct"] = (entry["candidate"]["prefill_tps"] / entry["baseline"]["prefill_tps"] - 1) * 100
+            entry["decode_pct"] = (entry["candidate"]["gen_tps"] / entry["baseline"]["gen_tps"] - 1) * 100
+            table.append(entry)
+        rec = {"ctx_max": ctx_max, "gen_tokens": self.args.gen_tokens, "runs": runs, "table": table,
+               "frontier_logits_exact": exact, "frontiers_compared": len(names)}
+        self.report["steps"]["sweep"] = rec
+        self.save()
+        for e in table:
+            self.say(f"sweep ctx={e['ctx']}: prefill {e['baseline']['prefill_tps']:.1f} -> "
+                     f"{e['candidate']['prefill_tps']:.1f} ({e['prefill_pct']:+.2f}%), decode "
+                     f"{e['baseline']['gen_tps']:.2f} -> {e['candidate']['gen_tps']:.2f} ({e['decode_pct']:+.2f}%)")
+        self.say(f"sweep frontier logits: {'EXACT' if exact else 'MISMATCH'} over {len(names)} frontiers")
+        return exact
+
+    # ---------------------------------------------------------------- decode
+    def decode(self):
+        """Short-prompt plain and MTP decode through the CLI compare harness."""
+        rec = {}
+        for mode in ("plain", "mtp"):
+            d = self.out / "decode" / mode
+            cmd = [sys.executable, str(ROOT / "speed-bench" / "qwen38_mtp_compare.py"),
+                   "--model", str(self.model), "--ple", str(self.ple),
+                   "--baseline", str(self.base / "ds4"),
+                   "--baseline-source", str(self.base / "metal" / "qwen4.metal"),
+                   "--baseline-moe-source", str(self.base / "metal" / "moe.metal"),
+                   "--candidate", str(self.cand / "ds4"),
+                   "--candidate-source", str(self.cand / "metal" / "qwen4.metal"),
+                   "--candidate-moe-source", str(self.cand / "metal" / "moe.metal"),
+                   "--ctx", "8192", "--repeats", str(self.args.decode_repeats), "--out", str(d)]
+            for kv in self.args.candidate_env:
+                cmd += ["--candidate-env", kv]
+            if mode == "plain":
+                cmd.append("--no-mtp")
+            d.mkdir(parents=True, exist_ok=True)
+            wall = self.run("candidate", cmd, d / "compare", cwd=ROOT, env=clean_env())
+            res = json.loads((d / "results.json").read_text())
+            rec[mode] = {"summary": res["summary"], "wall_s": wall}
+            for case, s in res["summary"].items():
+                self.say(f"decode {mode} {case}: {s['median_tps']['baseline']:.2f} -> "
+                         f"{s['median_tps']['candidate']:.2f} ({(s['speedup'] - 1) * 100:+.2f}%) "
+                         f"outputs {'identical' if s['all_outputs_identical'] else 'DIFFER'}")
+        self.report["steps"]["decode"] = rec
+        self.save()
+        return all(s["all_outputs_identical"] and s["acceptance_identical"]
+                   for m in rec.values() for s in m["summary"].values())
+
+    # -------------------------------------------------------------- mtp-long
+    def mtp_long(self):
+        """MTP decode after long raw prompts, both builds interleaved."""
+        d = self.out / "mtp-long"
+        d.mkdir(exist_ok=True)
+        text = self.prompt.read_text(errors="ignore")
+        rec = {}
+        for chars in self.args.long_chars:
+            slice_path = d / f"prompt-{chars}.txt"
+            slice_path.write_text(text[:chars])
+            runs = []
+            for rep in range(self.args.long_repeats):
+                for build in (["baseline", "candidate"] if rep % 2 == 0 else ["candidate", "baseline"]):
+                    stem = d / f"{chars}-{build}-r{rep}"
+                    cmd = [str(self.builds[build] / "ds4"), "-m", str(self.model), "--ple", str(self.ple),
+                           "--metal", "--ctx", str(self.args.long_ctx), "-n", str(self.args.long_tokens),
+                           "--temp", "0", "--nothink", "--mtp", "--mtp-timing",
+                           "--prompt-file", str(slice_path), "--raw-prompt"]
+                    wall = self.run(build, cmd, stem)
+                    log = stem.with_suffix(".stderr").read_text()
+                    rates, accepts = RATE.findall(log), ACCEPT.findall(log)
+                    r = {"build": build, "rep": rep, "prefill_tps": float(rates[-1][0]),
+                         "decode_tps": float(rates[-1][1]),
+                         "cycles": int(accepts[-1][0]) if accepts else 0,
+                         "accepted": int(accepts[-1][1]) if accepts else 0,
+                         "output_sha256": sha256(stem.with_suffix(".stdout")), "wall_s": wall}
+                    runs.append(r)
+                    self.say(f"mtp-long {chars} {build} r{rep}: prefill {r['prefill_tps']:.1f} decode "
+                             f"{r['decode_tps']:.2f} accepted {r['accepted']}/{r['cycles']}")
+            med = {b: statistics.median(r["decode_tps"] for r in runs if r["build"] == b) for b in self.builds}
+            rec[str(chars)] = {"runs": runs, "median_decode_tps": med,
+                               "decode_pct": (med["candidate"] / med["baseline"] - 1) * 100,
+                               "outputs_identical": len({r["output_sha256"] for r in runs}) == 1,
+                               "acceptance_identical": len({(r["accepted"], r["cycles"]) for r in runs}) == 1}
+            self.say(f"mtp-long {chars}: {med['baseline']:.2f} -> {med['candidate']:.2f} "
+                     f"({rec[str(chars)]['decode_pct']:+.2f}%) outputs "
+                     f"{'identical' if rec[str(chars)]['outputs_identical'] else 'DIFFER'}")
+        self.report["steps"]["mtp_long"] = rec
+        self.save()
+        return all(v["outputs_identical"] and v["acceptance_identical"] for v in rec.values())
+
+    # ---------------------------------------------------------------- env A/B
+    def prefill_ab(self):
+        d = self.out / "prefill-ab"
+        d.mkdir(exist_ok=True)
+        name, _, value = self.args.ab_env.partition("=")
+        cmd = [str(self.cand / "speed-bench" / "metal_prefill_variant_bench"), "-m", str(self.model),
+               "--ple", str(self.ple), "--prompt-file", str(self.prompt),
+               "--prefill-chunk", str(self.args.ab_chunk), "--prefix-tokens", str(self.args.ab_prefix),
+               "--warmup-tokens", str(self.args.ab_warmup), "--candidate-env", name,
+               "--candidate-value", value or "1", "--repeats", str(self.args.ab_repeats)]
+        if self.args.ab_initial:
+            cmd += ["--initial-tokens", str(self.args.ab_initial)]
+        wall = self.run("candidate", cmd, d / "run", cwd=ROOT)
+        out = (d / "run.stdout").read_text()
+        self.say(out.strip().splitlines()[-1] if out.strip() else "no output")
+        self.report["steps"]["prefill_ab"] = {"env": self.args.ab_env, "stdout": out, "wall_s": wall}
+        self.save()
+
+    def decode_ab(self):
+        d = self.out / "decode-ab"
+        d.mkdir(exist_ok=True)
+        cmd = [str(self.cand / "speed-bench" / "qwen38_decode_variant_bench"), "-m", str(self.model),
+               "--ple", str(self.ple), "--prompt-file", str(self.prompt),
+               "--prefix-tokens", str(self.args.ab_prefix), "--warmup", str(self.args.ab_warmup),
+               "--tokens", str(self.args.ab_tokens)]
+        for kv in self.args.ab_env.split(","):
+            cmd += ["--candidate-env", kv]
+        for kv in self.args.ab_control_env:
+            cmd += ["--control-env", kv]
+        wall = self.run("candidate", cmd, d / "run", cwd=ROOT)
+        out = (d / "run.stdout").read_text()
+        for line in out.strip().splitlines():
+            self.say(line)
+        self.report["steps"]["decode_ab"] = {"env": self.args.ab_env, "stdout": out, "wall_s": wall}
+        self.save()
+
+    # ------------------------------------------------------------------ gate
+    def gate(self):
+        ok = self.parity()
+        if not ok and not self.args.keep_going:
+            self.say("parity FAILED; stopping the gate")
+            self.summary(False)
+            return False
+        ok &= self.decode()
+        ok &= self.sweep()
+        if self.args.long_chars:
+            ok &= self.mtp_long()
+        self.summary(ok)
+        return ok
+
+    def summary(self, ok):
+        s = self.report["steps"]
+        lines = [f"# Lab {self.args.name}", "",
+                 f"baseline `{self.report['builds']['baseline']['head']}` vs candidate "
+                 f"`{self.report['builds']['candidate']['head']}`; candidate env "
+                 f"`{self.report['candidate_env'] or 'none'}`; exact: **{'yes' if ok else 'NO'}**", ""]
+        if "parity" in s:
+            lines += [f"- parity: {'EXACT' if s['parity']['exact'] else 'MISMATCH'} on "
+                      f"{len(s['parity']['checks'])} teacher-forced histories x 32 rows"]
+        if "decode" in s:
+            for mode, m in s["decode"].items():
+                for case, v in m["summary"].items():
+                    lines.append(f"- decode {mode} {case}: {v['median_tps']['baseline']:.2f} -> "
+                                 f"{v['median_tps']['candidate']:.2f} t/s ({(v['speedup'] - 1) * 100:+.2f}%)")
+        if "sweep" in s:
+            lines += ["", "| ctx | prefill base | prefill cand | prefill % | decode base | decode cand | decode % |",
+                      "|---:|---:|---:|---:|---:|---:|---:|"]
+            for e in s["sweep"]["table"]:
+                lines.append(f"| {e['ctx']} | {e['baseline']['prefill_tps']:.1f} | {e['candidate']['prefill_tps']:.1f} "
+                             f"| {e['prefill_pct']:+.2f} | {e['baseline']['gen_tps']:.2f} | "
+                             f"{e['candidate']['gen_tps']:.2f} | {e['decode_pct']:+.2f} |")
+            lines.append(f"\nfrontier logits: {'EXACT' if s['sweep']['frontier_logits_exact'] else 'MISMATCH'} "
+                         f"over {s['sweep']['frontiers_compared']} frontiers")
+        if "mtp_long" in s:
+            for chars, v in s["mtp_long"].items():
+                lines.append(f"- mtp-long {chars} chars: {v['median_decode_tps']['baseline']:.2f} -> "
+                             f"{v['median_decode_tps']['candidate']:.2f} t/s ({v['decode_pct']:+.2f}%)")
+        (self.out / "summary.md").write_text("\n".join(lines) + "\n")
+        self.report["exact"] = ok
+        self.save()
+        self.say("\n".join(lines))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("command", choices=["parity", "sweep", "decode", "mtp-long", "prefill-ab", "decode-ab", "gate"])
+    ap.add_argument("--name", default=datetime.now().strftime("%Y%m%d-%H%M%S"))
+    ap.add_argument("--out")
+    ap.add_argument("--base", default=str(DEFAULT_BASE))
+    ap.add_argument("--model", default=str(DEFAULT_MODEL))
+    ap.add_argument("--ple", default=str(DEFAULT_PLE))
+    ap.add_argument("--prompt", default=str(DEFAULT_PROMPT))
+    ap.add_argument("--candidate-env", action="append", default=[], metavar="NAME=VALUE",
+                    help="environment applied to the candidate build in parity/sweep/decode/mtp-long")
+    ap.add_argument("--ctx-start", type=int, default=4096)
+    ap.add_argument("--ctx-max", type=int, default=131072)
+    ap.add_argument("--gen-tokens", type=int, default=128)
+    ap.add_argument("--sweep-orders", type=int, default=2, help="1: baseline then candidate; 2: both orders")
+    ap.add_argument("--decode-repeats", type=int, default=3)
+    ap.add_argument("--long-chars", type=int, action="append", default=[], help="raw prompt slice sizes for mtp-long")
+    ap.add_argument("--long-ctx", type=int, default=140000)
+    ap.add_argument("--long-tokens", type=int, default=256)
+    ap.add_argument("--long-repeats", type=int, default=2)
+    ap.add_argument("--ab-env", default="", help="NAME[=VALUE][,NAME=VALUE...] for prefill-ab/decode-ab")
+    ap.add_argument("--ab-control-env", action="append", default=[])
+    ap.add_argument("--ab-prefix", type=int, default=8192)
+    ap.add_argument("--ab-initial", type=int, default=0)
+    ap.add_argument("--ab-chunk", type=int, default=8192)
+    ap.add_argument("--ab-warmup", type=int, default=32)
+    ap.add_argument("--ab-repeats", type=int, default=2)
+    ap.add_argument("--ab-tokens", type=int, default=512)
+    ap.add_argument("--keep-going", action="store_true")
+    args = ap.parse_args()
+    lab = Lab(args)
+    ok = {"parity": lab.parity, "sweep": lab.sweep, "decode": lab.decode, "mtp-long": lab.mtp_long,
+          "prefill-ab": lab.prefill_ab, "decode-ab": lab.decode_ab, "gate": lab.gate}[args.command]()
+    if ok is False:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/speed-bench/qwen38_m5_lab.py
+++ b/speed-bench/qwen38_m5_lab.py
@@ -7,8 +7,9 @@ and every accepted change must keep full-vocabulary FP32 logits byte-identical.
 
 Subcommands:
   parity     teacher-forced full-logit parity (1..128 prompt tokens, 32 rows each)
-  sweep      ds4-bench prefill+greedy-decode sweep for both builds, both orders,
-             with per-frontier logit dumps compared byte for byte
+  sweep      per-frontier ds4-bench prefill+greedy-decode runs, four fresh
+             processes per frontier in ABBA/BAAB order, frontier logits
+             compared byte for byte across all four
   decode     short-prompt plain decode and MTP decode (qwen38_mtp_compare.py)
   mtp-long   MTP decode on long raw prompts (32K/128K), both builds interleaved
   prefill-ab single-engine env A/B (metal_prefill_variant_bench)
@@ -154,59 +155,73 @@ class Lab:
         return ok
 
     # ----------------------------------------------------------------- sweep
-    def sweep_one(self, build, tag, ctx_max):
+    def sweep_one(self, build, tag, ctx):
+        """One frontier in one process: prefill ctx tokens, then greedy decode."""
         d = self.out / "sweep" / f"{tag}-{build}"
         (d / "logits").mkdir(parents=True, exist_ok=True)
         gen = self.args.gen_tokens
         cmd = [str(self.builds[build] / "ds4-bench"), "-m", str(self.model), "--ple", str(self.ple), "--metal",
-               "--prompt-file", str(self.prompt), "--ctx-start", str(self.args.ctx_start),
-               "--ctx-max", str(ctx_max), "--step-mul", "2", "--gen-tokens", str(gen),
-               "--csv", str(d / "speed.csv"), "--dump-frontier-logits-dir", str(d / "logits")]
+               "--prompt-file", str(self.prompt), "--ctx-start", str(ctx), "--ctx-max", str(ctx),
+               "--gen-tokens", str(gen), "--csv", str(d / "speed.csv"),
+               "--dump-frontier-logits-dir", str(d / "logits")]
+        if self.args.prefill_chunk:
+            cmd += ["--prefill-chunk", str(self.args.prefill_chunk)]
         env = self.env_for(build)
         env["DS4_BENCH_FORCE_SNAPSHOT"] = "1"
         wall = self.run(build, cmd, d / "bench", env=env)
-        rows = []
-        for line in (d / "speed.csv").read_text().splitlines()[1:]:
-            f = line.split(",")
-            rows.append({"ctx": int(f[0]), "prefill_tokens": int(f[1]), "prefill_tps": float(f[2]),
-                         "gen_tps": float(f[4]), "gen_first_ms": float(f[5]), "gen_steady_tps": float(f[7])})
+        f = (d / "speed.csv").read_text().splitlines()[1].split(",")
+        row = {"ctx": int(f[0]), "prefill_tokens": int(f[1]), "prefill_tps": float(f[2]),
+               "gen_tps": float(f[4]), "gen_first_ms": float(f[5]), "gen_steady_tps": float(f[7])}
         logits = {p.name: sha256(p) for p in sorted((d / "logits").glob("frontier_*.logits.json"))}
-        self.say(f"sweep {tag} {build}: {wall:.0f}s " +
-                 " ".join(f"{r['ctx']}:{r['prefill_tps']:.0f}/{r['gen_tps']:.2f}" for r in rows))
-        return {"rows": rows, "logits_sha256": logits, "wall_s": wall}
+        self.say(f"sweep {tag} {build}: {wall:.0f}s prefill {row['prefill_tps']:.1f} decode {row['gen_tps']:.2f}")
+        return {"row": row, "logits_sha256": logits, "wall_s": wall}
+
+    def sweep_ctxs(self):
+        if self.args.sweep_ctx:
+            return [int(c) for c in self.args.sweep_ctx.split(",")]
+        ctxs, c = [], self.args.ctx_start
+        while c < self.args.ctx_max:
+            ctxs.append(c)
+            c *= 2
+        return ctxs + [self.args.ctx_max]
 
     def sweep(self):
-        ctx_max = self.args.ctx_max
-        runs = {}
-        order = [["baseline", "candidate"], ["candidate", "baseline"]][: self.args.sweep_orders]
-        for i, pair in enumerate(order):
-            for build in pair:
-                runs[f"r{i}-{build}"] = self.sweep_one(build, f"r{i}", ctx_max)
-        # exactness: every frontier dump must match across all runs
-        names = sorted({n for r in runs.values() for n in r["logits_sha256"]})
-        exact = all(len({r["logits_sha256"].get(n) for r in runs.values()}) == 1 for n in names)
-        # per-context means
-        ctxs = sorted({row["ctx"] for r in runs.values() for row in r["rows"]})
-        table = []
-        for ctx in ctxs:
-            entry = {"ctx": ctx}
-            for build in self.builds:
-                vals = [row for k, r in runs.items() if k.endswith(build) for row in r["rows"] if row["ctx"] == ctx]
-                entry[build] = {"prefill_tps": statistics.mean(v["prefill_tps"] for v in vals),
-                                "gen_tps": statistics.mean(v["gen_tps"] for v in vals),
-                                "gen_steady_tps": statistics.mean(v["gen_steady_tps"] for v in vals)}
+        """Per frontier, four fresh processes in ABBA (or BAAB) order.
+
+        Sustained GPU load drifts the machine by 10-20% over a few minutes,
+        so builds are interleaved within each frontier rather than run as two
+        long sweeps; every frontier's logits must match across all four runs.
+        """
+        runs, table, exact = {}, [], True
+        for i, ctx in enumerate(self.sweep_ctxs()):
+            pattern = ["baseline", "candidate", "candidate", "baseline"]
+            if i % 2:
+                pattern.reverse()
+            per = {b: [] for b in self.builds}
+            hashes = set()
+            for slot, build in enumerate(pattern):
+                r = self.sweep_one(build, f"c{ctx}-s{slot}", ctx)
+                runs[f"c{ctx}-s{slot}-{build}"] = r
+                per[build].append(r["row"])
+                hashes.update(r["logits_sha256"].values())
+            entry = {"ctx": ctx, "exact": len(hashes) == 1}
+            exact &= entry["exact"]
+            for b, rows in per.items():
+                entry[b] = {"prefill_tps": statistics.mean(v["prefill_tps"] for v in rows),
+                            "gen_tps": statistics.mean(v["gen_tps"] for v in rows),
+                            "gen_steady_tps": statistics.mean(v["gen_steady_tps"] for v in rows)}
             entry["prefill_pct"] = (entry["candidate"]["prefill_tps"] / entry["baseline"]["prefill_tps"] - 1) * 100
             entry["decode_pct"] = (entry["candidate"]["gen_tps"] / entry["baseline"]["gen_tps"] - 1) * 100
             table.append(entry)
-        rec = {"ctx_max": ctx_max, "gen_tokens": self.args.gen_tokens, "runs": runs, "table": table,
-               "frontier_logits_exact": exact, "frontiers_compared": len(names)}
-        self.report["steps"]["sweep"] = rec
-        self.save()
-        for e in table:
-            self.say(f"sweep ctx={e['ctx']}: prefill {e['baseline']['prefill_tps']:.1f} -> "
-                     f"{e['candidate']['prefill_tps']:.1f} ({e['prefill_pct']:+.2f}%), decode "
-                     f"{e['baseline']['gen_tps']:.2f} -> {e['candidate']['gen_tps']:.2f} ({e['decode_pct']:+.2f}%)")
-        self.say(f"sweep frontier logits: {'EXACT' if exact else 'MISMATCH'} over {len(names)} frontiers")
+            self.say(f"sweep ctx={ctx}: prefill {entry['baseline']['prefill_tps']:.1f} -> "
+                     f"{entry['candidate']['prefill_tps']:.1f} ({entry['prefill_pct']:+.2f}%), decode "
+                     f"{entry['baseline']['gen_tps']:.2f} -> {entry['candidate']['gen_tps']:.2f} "
+                     f"({entry['decode_pct']:+.2f}%), logits {'EXACT' if entry['exact'] else 'MISMATCH'}")
+            rec = {"gen_tokens": self.args.gen_tokens, "runs": runs, "table": table,
+                   "frontier_logits_exact": exact, "frontiers_compared": len(table)}
+            self.report["steps"]["sweep"] = rec
+            self.save()
+        self.say(f"sweep frontier logits: {'EXACT' if exact else 'MISMATCH'} over {len(table)} frontiers")
         return exact
 
     # ---------------------------------------------------------------- decode
@@ -379,7 +394,8 @@ def main():
     ap.add_argument("--ctx-start", type=int, default=4096)
     ap.add_argument("--ctx-max", type=int, default=131072)
     ap.add_argument("--gen-tokens", type=int, default=128)
-    ap.add_argument("--sweep-orders", type=int, default=2, help="1: baseline then candidate; 2: both orders")
+    ap.add_argument("--sweep-ctx", default="", help="comma-separated frontiers (default: doubling ctx-start..ctx-max)")
+    ap.add_argument("--prefill-chunk", type=int, default=0)
     ap.add_argument("--decode-repeats", type=int, default=3)
     ap.add_argument("--long-chars", type=int, action="append", default=[], help="raw prompt slice sizes for mtp-long")
     ap.add_argument("--long-ctx", type=int, default=140000)

--- a/speed-bench/qwen38_timeline_report.py
+++ b/speed-bench/qwen38_timeline_report.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Aggregate a DS4_METAL_ENCODER_TIMELINE log per kernel.
+
+Each timestamped encoder holds one dispatch when the timeline is active, so
+the log attributes GPU time to individual kernels.  Batches (command buffers)
+whose total duration exceeds --max-batch-ms are treated as prefill and
+skipped, leaving the decode tokens; per-kernel totals are then divided by the
+number of decode batches so the table reads as microseconds per token.
+"""
+import argparse
+import collections
+import sys
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("log")
+    ap.add_argument("--max-batch-ms", type=float, default=200.0)
+    ap.add_argument("--skip-batches", type=int, default=2, help="warm-up batches to ignore")
+    ap.add_argument("--top", type=int, default=40)
+    ap.add_argument("--batches-per-token", type=int, default=2,
+                    help="command buffers per decode token (flush at layer 2 gives two)")
+    a = ap.parse_args()
+    batches = collections.OrderedDict()
+    for line in open(a.log):
+        if not line.startswith("E "):
+            continue
+        f = line.split()
+        seq, idx = int(f[1]), int(f[2])
+        dur, gap = float(f[5]), float(f[6])
+        kernel = f[11] if len(f) > 11 else "?"
+        tg, tpt = f[9], f[10]
+        batches.setdefault(seq, []).append((idx, dur, gap, kernel, tg, tpt))
+    decode = [(seq, recs) for seq, recs in batches.items()
+              if sum(r[1] for r in recs) < a.max_batch_ms * 1000.0]
+    decode = decode[a.skip_batches:]
+    if not decode:
+        sys.exit("no decode batches found")
+    n_tokens = max(1, len(decode) // a.batches_per_token)
+    per = collections.defaultdict(lambda: [0, 0.0, 0.0, set()])
+    total_dur = total_gap = 0.0
+    n_dispatch = 0
+    for _, recs in decode:
+        for _, dur, gap, kernel, tg, tpt in recs:
+            p = per[kernel]
+            p[0] += 1
+            p[1] += dur
+            p[2] += gap
+            p[3].add(f"{tg}/{tpt}")
+            total_dur += dur
+            total_gap += gap
+            n_dispatch += 1
+    print(f"decode batches: {len(decode)} (~{n_tokens} tokens), dispatches/token: {n_dispatch / n_tokens:.0f}, "
+          f"gpu busy/token: {total_dur / n_tokens / 1000:.3f} ms, gaps/token: {total_gap / n_tokens / 1000:.3f} ms")
+    print(f"{'kernel':<56} {'n/tok':>6} {'us/tok':>9} {'%':>6} {'us/disp':>8} {'gap/tok':>8}  grids")
+    rows = sorted(per.items(), key=lambda kv: -kv[1][1])
+    for kernel, (n, dur, gap, grids) in rows[: a.top]:
+        print(f"{kernel:<56} {n / n_tokens:>6.1f} {dur / n_tokens:>9.1f} {100 * dur / total_dur:>6.2f} "
+              f"{dur / n:>8.2f} {gap / n_tokens:>8.1f}  {' '.join(sorted(grids))[:60]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_qwen4_kernels.c
+++ b/tests/test_qwen4_kernels.c
@@ -752,7 +752,7 @@ static void test_idx_score_mm(uint32_t T, uint32_t n, uint32_t pos0) {
     ds4_gpu_tensor *gk = ds4_gpu_tensor_alloc((uint64_t)n * Di * 2);
     ds4_gpu_tensor *gs = upload(NULL, (uint64_t)T * n);
     require_ok(gq && gk && gs && ds4_gpu_tensor_write(gk, 0, keyh, (uint64_t)n * Di * 2) &&
-               ds4_gpu_qwen4_idx_score_tensor(gs, gq, gk, T, n, Hi, Di, pos0, ratio), "idx score mm");
+               ds4_gpu_qwen4_idx_score_tensor(gs, NULL, gq, gk, T, n, Hi, Di, pos0, ratio), "idx score mm");
     float *got = download(gs, (uint64_t)T * n);
     /* invisible entries are -3e38 on both sides: compare them exactly by mapping to 0 */
     for (uint64_t i = 0; i < (uint64_t)T * n; i++) {
@@ -788,7 +788,7 @@ static void test_idx_select(uint32_t T, uint32_t n, uint32_t k, uint32_t visible
     }
     ds4_gpu_tensor *gs = upload(sc, (uint64_t)T * n);
     ds4_gpu_tensor *gsel = ds4_gpu_tensor_alloc((uint64_t)T * k * 4);
-    require_ok(gs && gsel && ds4_gpu_qwen4_idx_select_tensor(gsel, gs, n, T, k), "idx select");
+    require_ok(gs && gsel && ds4_gpu_qwen4_idx_select_tensor(gsel, gs, NULL, n, T, k), "idx select");
     int32_t *got = malloc((uint64_t)T * k * 4);
     require_ok(ds4_gpu_tensor_read(gsel, 0, got, (uint64_t)T * k * 4), "idx select read");
     int32_t *order = malloc((uint64_t)n * 4);
@@ -1183,8 +1183,8 @@ static void test_attention(arena_t *a, uint32_t H, uint32_t Hkv, uint32_t D, uin
         }
         const bool sparse = n_blocks > k_blocks;
         if (sparse) {
-            require_ok(ds4_gpu_qwen4_idx_score_tensor(gscore, giqo, gbk, 1, n_blocks, Hi, Di, pos, ratio), "idx score");
-            require_ok(ds4_gpu_qwen4_idx_select_tensor(gselb, gscore, n_blocks, 1, k_blocks), "idx select");
+            require_ok(ds4_gpu_qwen4_idx_score_tensor(gscore, NULL, giqo, gbk, 1, n_blocks, Hi, Di, pos, ratio), "idx score");
+            require_ok(ds4_gpu_qwen4_idx_select_tensor(gselb, gscore, NULL, n_blocks, 1, k_blocks), "idx select");
             {   /* the radix select must pick the argsort's set (order may differ) */
                 ds4_gpu_tensor *gref = ds4_gpu_tensor_alloc((uint64_t)k_blocks * 4);
                 require_ok(gref && ds4_gpu_indexer_topk_tensor(gref, gscore, n_blocks, 1, k_blocks), "topk ref");
@@ -1229,6 +1229,91 @@ static uint64_t arena_tier(arena_t *a, uint32_t wtype, uint64_t rows, uint64_t c
 }
 
 static void check_exact_f32(const char *what, const float *got, const float *ref, uint64_t n);
+
+/* The vector scorer must reproduce the scalar scorer bit for bit and emit
+ * the selector's tile keys; the prefiltered decode select must reproduce
+ * the full-row select bit for bit, including tie order at both ends. */
+static void test_idx_prefilter(void) {
+    const uint32_t Hi = 4, Di = 128, k = 512;
+    const uint32_t sizes[3] = { 4104u, 16384u, 65536u };
+    for (uint32_t si = 0; si < 3; si++) {
+        for (uint32_t T = 1; T <= 2; T++) {
+            const uint32_t n = sizes[si], n_tiles = (n + 7u) / 8u;
+            const uint32_t ratio = 4, pos0 = ratio * (n - 3u) + 1u;   /* the last tokens see n-2.. blocks */
+            float *q = rand_vec((uint64_t)T * Hi * Di, 1.0f);
+            float *keyf = rand_vec((uint64_t)n * Di, 1.0f);
+            uint16_t *keyh = malloc((uint64_t)n * Di * 2);
+            for (uint64_t i = 0; i < (uint64_t)n * Di; i++) keyh[i] = f32_to_f16(keyf[i]);
+            ds4_gpu_tensor *gq = upload(q, (uint64_t)T * Hi * Di);
+            ds4_gpu_tensor *gk = ds4_gpu_tensor_alloc((uint64_t)n * Di * 2);
+            ds4_gpu_tensor *gs0 = upload(NULL, (uint64_t)T * n), *gs1 = upload(NULL, (uint64_t)T * n);
+            ds4_gpu_tensor *gtm = ds4_gpu_tensor_alloc((uint64_t)T * n_tiles * 4);
+            require_ok(gq && gk && gs0 && gs1 && gtm && ds4_gpu_tensor_write(gk, 0, keyh, (uint64_t)n * Di * 2), "prefilter setup");
+            setenv("DS4_QWEN4_IDX_SCORE_VEC", "0", 1);
+            require_ok(ds4_gpu_qwen4_idx_score_tensor(gs0, NULL, gq, gk, T, n, Hi, Di, pos0, ratio), "scalar score");
+            setenv("DS4_QWEN4_IDX_SCORE_VEC", "1", 1);
+            require_ok(ds4_gpu_qwen4_idx_score_tensor(gs1, gtm, gq, gk, T, n, Hi, Di, pos0, ratio), "vector score");
+            unsetenv("DS4_QWEN4_IDX_SCORE_VEC");
+            float *s0 = download(gs0, (uint64_t)T * n), *s1 = download(gs1, (uint64_t)T * n);
+            require_ok(memcmp(s0, s1, (uint64_t)T * n * 4) == 0, "vector scorer matches the scalar scorer");
+            uint32_t *tm = malloc((uint64_t)T * n_tiles * 4);
+            require_ok(ds4_gpu_tensor_read(gtm, 0, tm, (uint64_t)T * n_tiles * 4), "tile max read");
+            for (uint32_t t = 0; t < T; t++) {
+                for (uint32_t tile = 0; tile < n_tiles; tile++) {
+                    uint32_t m = 0;
+                    for (uint32_t j = 0; j < 8 && tile * 8 + j < n; j++) {
+                        const float v = fmaxf(s1[(uint64_t)t * n + tile * 8 + j], 0.0f);
+                        uint32_t key; memcpy(&key, &v, 4);
+                        if (key > m) m = key;
+                    }
+                    require_ok(tm[(uint64_t)t * n_tiles + tile] == m, "tile maximum matches the score keys");
+                }
+            }
+            /* selection on the real scores, then on rows with ties at both ends */
+            for (uint32_t variant = 0; variant < 2; variant++) {
+                if (variant) {
+                    for (uint32_t t = 0; t < T; t++) {
+                        for (uint32_t b = 0; b < n; b++) {
+                            float *v = &s1[(uint64_t)t * n + b];
+                            if (*v < -1e37f) continue;
+                            if ((b % 5) == 2) *v = s1[(uint64_t)t * n + (b / 5) * 5];   /* duplicates */
+                            if ((b % 1000) == 999) *v = 64.0f;                          /* top ties across tiles */
+                            if ((b % 3) == 1) *v = 0.0f;                                /* zeros: bottom ties */
+                        }
+                    }
+                    require_ok(ds4_gpu_tensor_write(gs1, 0, s1, (uint64_t)T * n * 4), "tie rows upload");
+                    for (uint32_t t = 0; t < T; t++) {
+                        for (uint32_t tile = 0; tile < n_tiles; tile++) {
+                            uint32_t m = 0;
+                            for (uint32_t j = 0; j < 8 && tile * 8 + j < n; j++) {
+                                const float v = fmaxf(s1[(uint64_t)t * n + tile * 8 + j], 0.0f);
+                                uint32_t key; memcpy(&key, &v, 4);
+                                if (key > m) m = key;
+                            }
+                            tm[(uint64_t)t * n_tiles + tile] = m;
+                        }
+                    }
+                    require_ok(ds4_gpu_tensor_write(gtm, 0, tm, (uint64_t)T * n_tiles * 4), "tie tiles upload");
+                }
+                ds4_gpu_tensor *gfull = ds4_gpu_tensor_alloc((uint64_t)T * k * 4), *gpre = ds4_gpu_tensor_alloc((uint64_t)T * k * 4);
+                setenv("DS4_QWEN4_IDX_PREFILTER", "0", 1);
+                require_ok(gfull && gpre && ds4_gpu_qwen4_idx_select_tensor(gfull, gs1, gtm, n, T, k), "full select");
+                setenv("DS4_QWEN4_IDX_PREFILTER", "1", 1);
+                require_ok(ds4_gpu_qwen4_idx_select_tensor(gpre, gs1, gtm, n, T, k), "prefiltered select");
+                unsetenv("DS4_QWEN4_IDX_PREFILTER");
+                int32_t *full = malloc((uint64_t)T * k * 4), *pre = malloc((uint64_t)T * k * 4);
+                require_ok(ds4_gpu_tensor_read(gfull, 0, full, (uint64_t)T * k * 4) &&
+                           ds4_gpu_tensor_read(gpre, 0, pre, (uint64_t)T * k * 4), "select read");
+                require_ok(memcmp(full, pre, (uint64_t)T * k * 4) == 0, "prefiltered select matches the full select");
+                free(full); free(pre);
+                ds4_gpu_tensor_free(gfull); ds4_gpu_tensor_free(gpre);
+            }
+            printf("  idx prefilter n=%u T=%u: vector scores, tile keys and selections byte-exact\n", n, T);
+            free(q); free(keyf); free(keyh); free(s0); free(s1); free(tm);
+            ds4_gpu_tensor_free(gq); ds4_gpu_tensor_free(gk); ds4_gpu_tensor_free(gs0); ds4_gpu_tensor_free(gs1); ds4_gpu_tensor_free(gtm);
+        }
+    }
+}
 
 /* Routed gate/up and down types can differ; shared experts stay Q8_0
  * for quantized cases and F32 for the F32 case. */
@@ -2180,13 +2265,13 @@ static int bench_p_hc_up_mm(void *ud) { bench_ctx *c = ud; return ds4_gpu_qwen4_
 static int bench_p_hc_mix_rows(void *ud) { bench_ctx *c = ud; return ds4_gpu_qwen4_hc_mix_rows_tensor(c->t[19], c->t[1], c->t[1], 256, 2560, 4); }
 static int bench_p_q8_gemm(void *ud) { bench_ctx *c = ud; return ds4_gpu_matmul_q8_0_tensor(c->t[1], c->a->base, c->a->size, c->off[1], 2560, 6144, c->t[18], 256); }
 static int bench_p_q8_mm(void *ud) { bench_ctx *c = ud; return ds4_gpu_qwen4_dense_mm_tensor(c->t[1], c->t[18], c->a->base, c->a->size, c->off[1], 8u, 256, 2560, 6144); }
-static int bench_p_idx_score(void *ud) { bench_ctx *c = ud; return ds4_gpu_qwen4_idx_score_tensor(c->t[26], c->t[24], c->t[25], 32, 65536, 4, 128, 262144, 4); }
+static int bench_p_idx_score(void *ud) { bench_ctx *c = ud; return ds4_gpu_qwen4_idx_score_tensor(c->t[26], NULL, c->t[24], c->t[25], 32, 65536, 4, 128, 262144, 4); }
 static int bench_p_idx_argsort(void *ud) { bench_ctx *c = ud; return ds4_gpu_indexer_topk_tensor(c->t[27], c->t[26], 65536, 32, 512); }
-static int bench_p_idx_select(void *ud) { bench_ctx *c = ud; return ds4_gpu_qwen4_idx_select_tensor(c->t[27], c->t[26], 65536, 32, 512); }
+static int bench_p_idx_select(void *ud) { bench_ctx *c = ud; return ds4_gpu_qwen4_idx_select_tensor(c->t[27], c->t[26], NULL, 65536, 32, 512); }
 static int bench_p_q8_gemm_2k(void *ud) { bench_ctx *c = ud; return ds4_gpu_matmul_q8_0_tensor(c->t[40], c->a->base, c->a->size, c->off[1], 2560, 6144, c->t[39], 2048); }
 static int bench_p_f16_gemm_2k(void *ud) { bench_ctx *c = ud; return ds4_gpu_matmul_f16_tensor(c->t[41], c->a->base, c->a->size, c->off[3], 10240, 320, c->t[42], 2048); }
-static int bench_p_idx_score_1k(void *ud) { bench_ctx *c = ud; return ds4_gpu_qwen4_idx_score_tensor(c->t[29], c->t[28], c->t[25], 1024, 65536, 4, 128, 262144 - 1024, 4); }
-static int bench_p_idx_select_1k(void *ud) { bench_ctx *c = ud; return ds4_gpu_qwen4_idx_select_tensor(c->t[30], c->t[29], 65536, 1024, 512); }
+static int bench_p_idx_score_1k(void *ud) { bench_ctx *c = ud; return ds4_gpu_qwen4_idx_score_tensor(c->t[29], NULL, c->t[28], c->t[25], 1024, 65536, 4, 128, 262144 - 1024, 4); }
+static int bench_p_idx_select_1k(void *ud) { bench_ctx *c = ud; return ds4_gpu_qwen4_idx_select_tensor(c->t[30], c->t[29], NULL, 65536, 1024, 512); }
 /* sparse prefill attention: 1024 queries at the end of a 256k context, 512 selected blocks each */
 static int bench_p_attn_sparse(void *ud) {
     bench_ctx *c = ud;
@@ -2463,6 +2548,7 @@ int main(void) {
         printf("all Qwen MoE decode specialization tests passed\n");
         return 0;
     }
+    if (getenv("DS4_TEST_QWEN4_IDX_PREFILTER_ONLY")) { test_idx_prefilter(); printf("all qwen4 indexer prefilter tests passed\n"); return 0; }
     const char *q4k_ordered_only = getenv("DS4_TEST_QWEN4_Q4K_ORDERED_ONLY");
     if (q4k_ordered_only && q4k_ordered_only[0] && strcmp(q4k_ordered_only, "0") != 0) {
         test_q4k_ordered_exact(&arena, 1, 640, true);

--- a/tests/test_qwen4_kernels.c
+++ b/tests/test_qwen4_kernels.c
@@ -1308,7 +1308,10 @@ static void test_moe_types(arena_t *a, uint32_t NE, uint32_t slots, uint32_t E, 
                                             sg_off, su_off, shared_type), "moe mid");
     require_ok(ds4_gpu_qwen4_moe_down_tensor(gpart, gmid, gsel, a->base, a->size, down_off, dtype, NE, T, slots, F, E,
                                              sd_off, shared_type), "moe down");
-    if (dtype == 10u && getenv("DS4_TEST_QWEN4_MV_EXACT")) {
+    if ((dtype == 10u || dtype == 39u) && getenv("DS4_TEST_QWEN4_MV_EXACT")) {
+        /* Specialized decode row kernels must match the generic dispatch bit
+         * for bit across every NR/NSG geometry; Q4_K gate/up keep their own
+         * ordered kernel, so a Q4_K/MXFP4 pair exercises the down rows. */
         const uint64_t nm = (uint64_t)T * n_out * F, np = (uint64_t)T * n_out * E;
         float *bm = malloc(nm * sizeof(float)), *bp = malloc(np * sizeof(float));
         float *am = malloc(nm * sizeof(float)), *ap = malloc(np * sizeof(float));
@@ -1326,8 +1329,8 @@ static void test_moe_types(arena_t *a, uint32_t NE, uint32_t slots, uint32_t E, 
             require_ok(ds4_gpu_tensor_read(gmid, 0, am, nm * sizeof(float)) &&
                        ds4_gpu_tensor_read(gpart, 0, ap, np * sizeof(float)), "exact read");
             if (!mode) { memcpy(bm, am, nm * sizeof(float)); memcpy(bp, ap, np * sizeof(float)); }
-            else { check_exact_f32("specialized IQ2 mid", am, bm, nm);
-                   check_exact_f32("specialized Q2 down", ap, bp, np); }
+            else { check_exact_f32(dtype == 10u ? "specialized IQ2 mid" : "Q4K mid beside specialized down", am, bm, nm);
+                   check_exact_f32(dtype == 10u ? "specialized Q2 down" : "specialized MXFP4 down", ap, bp, np); }
         }
         unsetenv("DS4_QWEN4_MOE_MV_SPECIALIZE");
         unsetenv("DS4_QWEN4_MOE_MV_NR");
@@ -2453,6 +2456,10 @@ int main(void) {
         test_moe_types(&arena, 8, 6, 2560, 640, 2, 16u, 10u);
         test_moe_types(&arena, 8, 6, 256, 256, 9, 16u, 10u);
         test_moe_types(&arena, 8, 6, 256, 672, 3, 16u, 10u);
+        test_moe_types(&arena, 8, 6, 2560, 640, 1, 12u, 39u);
+        test_moe_types(&arena, 8, 6, 2560, 640, 2, 12u, 39u);
+        test_moe_types(&arena, 8, 6, 256, 256, 9, 12u, 39u);
+        test_moe_types(&arena, 8, 6, 256, 672, 3, 12u, 39u);
         printf("all Qwen MoE decode specialization tests passed\n");
         return 0;
     }


### PR DESCRIPTION
## Summary

Two optimization rounds for Qwen3.8-Flash-Next on an Apple M5 Max (128 GB, 40-core GPU), rebased on `qwen3.8-flash-next` at b85a617. Every change keeps full-vocabulary FP32 logits byte-identical (teacher-forced parity, per-step logit comparison in the A/B harness, per-frontier logit comparison in the sweeps); MTP outputs and acceptance counters are identical.

**M3 Ultra is unchanged by construction**: every kernel geometry and default below is gated on `ds4_gpu_device_is_m5_apple_silicon()`. The only device-independent behavior change is the MTP rejection rollback, which swaps the live and snapshot state buffers instead of blitting 36 layers back (exact; it removes a command buffer and a wait per rejected cycle, measured +0.8% on rejection-heavy prompts on M5). The reports include the exact commands to A/B each mechanism on M3 Ultra in ~35 s.

## Measured on M5 Max (Q4_K imatrix pack, fans at maximum)

Per-frontier interleaved sweep against the round-1 baseline (four fresh processes per frontier, 128 greedy tokens, frontier logits exact):

| ctx | prefill | decode |
| ---: | ---: | ---: |
| 4,096 | +9.2% | +5.7% |
| 32,768 | +10.8% | +7.0% |
| 131,072 | +8.9% | +8.8% |

CLI greedy decode, three prompts, interleaved repeats: plain +5.7% (52.2 -> 55.2 t/s), MTP +3.2 to +4.1% (Fibonacci 80.1 t/s), outputs identical.

## What changed (M5 defaults unless noted)

- Round 1 re-qualified the M3 Ultra-gated defaults: routed MoE prefill GEMM specialization, remainder tiles, gate/up tile caps, hyper-connection RMS reuse; single-token Q4_K gate/up rows one per SIMD group with four groups per threadgroup; MXFP4 routed-down rows specialized with sixteen groups. The M3 Ultra ordinary-decode fusions measured slower on M5 and stay off there.
- Round 2: narrow single-token F16/F32 matvecs one row per SIMD group; 1024-thread GDN front threadgroups; expert-major prefill tile order; decode indexer scorer with staged queries and vector key loads; one-thread-per-dim split-attention merge with prefetched splits; exact tile-max prefiltered top-k for long contexts (fixture-pinned against the full-row select); MTP rollback by buffer swap (all devices).
- Tooling: a single-engine per-step interleaved decode A/B harness, `--extra-env/--control-env` and a chunk-interleaved mode for the prefill harness, a lab driver (parity, per-frontier sweeps, CLI decode, long-prompt MTP), and a per-kernel timeline aggregator. `speed-bench/qwen38-m5-round1.md` and `round2.md` record every measurement, the rejected variants, and the measurement pitfalls found on this machine (sustained-load drift, first-session penalty).

## Validation of this branch state

Kernel fixtures (`test-qwen4-kernels`, `DS4_TEST_QWEN4_MV_EXACT`, `DS4_TEST_QWEN4_IDX_PREFILTER_ONLY`, `test-qwen4-moe-mm-specialize`, `test_qwen4_conv_parallel`, `test_q8_prefill_variants`) pass on M5; against a build of b85a617 on the same machine: teacher-forced parity exact on 6 histories x 32 rows; CLI decode plain +5.4 to +5.7% and MTP +3.2 to +4.1% with identical outputs and acceptance counters; per-frontier sweep prefill +8.4% / +9.5% and decode +6.6% / +6.6% at 4K / 32K with frontier logits exact.

## What the maintainer can check on M3 Ultra

Nothing here should change M3 Ultra numbers except the MTP rollback swap. `speed-bench/qwen38-m5-round2.md` ("To measure on M3 Ultra") lists the one-line A/Bs for the mechanisms that might also pay there (one-row F16/F32 matvecs, 1024-thread GDN front, expert-major tiles, vector scorer + wide merge, prefiltered top-k); each run asserts logit equality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
